### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/apps/libwlclient/CMakeLists.txt
+++ b/apps/libwlclient/CMakeLists.txt
@@ -36,3 +36,9 @@ TARGET_LINK_LIBRARIES(
   libwlclient
   base
   PkgConfig::WAYLAND)
+INCLUDE(CheckSymbolExists)
+CHECK_SYMBOL_EXISTS(signalfd "sys/signalfd.h" HAVE_SIGNALFD)
+IF(NOT HAVE_SIGNALFD)
+  PKG_CHECK_MODULES(EPOLL REQUIRED IMPORTED_TARGET epoll-shim)
+  TARGET_LINK_LIBRARIES(libwlclient PkgConfig::EPOLL)
+ENDIF()

--- a/src/xdg_shell.c
+++ b/src/xdg_shell.c
@@ -114,7 +114,7 @@ void handle_new_surface(struct wl_listener *listener_ptr,
         // `wlr_scene_layer_surface` for popups of the WLR layer surface.
         break;
 
-    case WLR_XDG_SURFACE_ROLE_TOPLEVEL:
+    case WLR_XDG_SURFACE_ROLE_TOPLEVEL:;
 
         wlmtk_window_t *window_ptr = wlmtk_window_create_from_xdg_toplevel(
             wlr_xdg_surface_ptr, xdg_shell_ptr->server_ptr);

--- a/third_party/protocols/CMakeLists.txt
+++ b/third_party/protocols/CMakeLists.txt
@@ -41,3 +41,6 @@ ADD_LIBRARY(
   OBJECT
   wlr-layer-shell-unstable-v1-protocol.h
   xdg-shell-protocol.h)
+SET_TARGET_PROPERTIES(
+  protocol_headers PROPERTIES
+  LINKER_LANGUAGE C)


### PR DESCRIPTION
Depends on https://github.com/phkaeser/libbase/pull/2
Runtime requires `/proc` mounted for some features until ported to `sysctl`.
Also [packaged](https://www.freshports.org/x11-wm/wlmaker) for easier testing.

*I put my patches here into the public domain. CLA isn't an option for me due to lacking a Google Account which cannot be signed up for via Tor. Feel free to resubmit under differnt authorship (e.g., `git commit --amend --reset-author`) in order to satisfy CLA.*
