### PR TITLE
Workflow

### DIFF
--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -55,6 +55,7 @@ jobs:
       run: |
         export PKG_CONFIG_PATH="${{ env.INSTALL_PKGCONFIG_PATH }}"
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
+        export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
         echo "pkg: ${PKG_CONFIG_PATH}"
         echo "lib: ${LD_LIBRARY_PATH}"
         (cd ${{github.workspace}}/dependencies && cmake -DCMAKE_INSTALL_PREFIX:PATH=${{ env.INSTALL_PATH }} -B build)
@@ -65,6 +66,7 @@ jobs:
       run: |
         export PKG_CONFIG_PATH="${{ env.INSTALL_PKGCONFIG_PATH }}"
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
+        export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
         echo "pkg: ${PKG_CONFIG_PATH}"
         echo "lib: ${LD_LIBRARY_PATH}"
         cmake -B ${{github.workspace}}/build
@@ -73,6 +75,7 @@ jobs:
       # Build your program with the given configuration
       run: |
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
+        export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
         cmake --build ${{github.workspace}}/build
 
     - name: Build documentation.

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -87,12 +87,12 @@ jobs:
         echo "Packaging from ${HOME}..."
         cd ${HOME}
         tar -cvf wlmaker-head.tar wlmaker
-        echo "Packaged."
-        zip wlmaker-head.tar.zip wlmaker-head.tar
+        echo "Packaged, to ${{ github.workspace}}."
+        zip ${{ github.workspace }}/wlmaker-head.tar.zip wlmaker-head.tar
         ls -ld wlm*
 
     - name: Upload the tarball.
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: wlmaker-head
         path: wlmaker-head.tar.zip

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -84,16 +84,15 @@ jobs:
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
         export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
         cmake --install build/
-        echo "Packaging: cd ${HOME} && tar -cvf ${HOME}/wlmaker-head.tar wlmaker"
-        cd "${HOME}" && tar -cvf "${HOME}/wlmaker-head.tar" wlmaker
+        tar -cvf wlmaker-head.tar wlmaker
         echo "Packaged."
+        zip wlmaker-head.tar.zip wlmaker-head.tar
 
     - name: Upload the tarball.
       uses: actions/upload-artifact@v2
       with:
         name: wlmaker-head
-        # Note: Artefacts will be zipped.
-        path: wlmaker-head.tar
+        path: wlmaker-head.tar.zip
 
     - name: Run all tests
       run: |

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -85,6 +85,9 @@ jobs:
         export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
         cmake --install build/
         tar -cvf wlmaker-head.tar wlmaker
+        echo "Packaging..."
+        cd ${HOME}
+        tar -cvf wlmaker-head.tar wlmaker
         echo "Packaged."
         zip wlmaker-head.tar.zip wlmaker-head.tar
 

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -56,8 +56,6 @@ jobs:
         export PKG_CONFIG_PATH="${{ env.INSTALL_PKGCONFIG_PATH }}"
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
         export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
-        echo "pkg: ${PKG_CONFIG_PATH}"
-        echo "lib: ${LD_LIBRARY_PATH}"
         (cd ${{github.workspace}}/dependencies && cmake -DCMAKE_INSTALL_PREFIX:PATH=${{ env.INSTALL_PATH }} -B build)
         cmake --build ${{github.workspace}}/dependencies/build
 
@@ -67,8 +65,6 @@ jobs:
         export PKG_CONFIG_PATH="${{ env.INSTALL_PKGCONFIG_PATH }}"
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
         export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
-        echo "pkg: ${PKG_CONFIG_PATH}"
-        echo "lib: ${LD_LIBRARY_PATH}"
         cmake -B ${{github.workspace}}/build
 
     - name: Build wlmaker.
@@ -85,8 +81,8 @@ jobs:
       run: |
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
         export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
-        cmake -DCMAKE_INSTALL_PREFIX:PATH=${{ env.INSTALL_PATH }} --install ${{github.workspace}}/build
-        cd "${{ env.INSTALL_PATH }}" && tar -zcvf wlmaker-head.tar.gz wlmaker
+        cmake --install ${{github.workspace}}/build
+        cd "${HOME}" && tar -zcvf wlmaker-head.tar.gz wlmaker
 
     - name: Upload artifact.
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -88,14 +88,14 @@ jobs:
         cd ${HOME}
         tar -cvf wlmaker-head.tar wlmaker
         echo "Packaged, to ${{ github.workspace}}."
-        zip ${{ github.workspace }}/wlmaker-head.tar.zip wlmaker-head.tar
+        zip wlmaker-head.tar.zip wlmaker-head.tar
         ls -ld wlm*
 
     - name: Upload the tarball.
       uses: actions/upload-artifact@v4
       with:
         name: wlmaker-head
-        path: wlmaker-head.tar.zip
+        path: ${{ github.workspace }}/wlmaker-head.tar.zip
         if-no-files-found: error
 
     - name: Run all tests

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -15,11 +15,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    container:
+      image: debian:bookworm
+      
     steps:
     - name: Install package dependencies.
       run: |
-        sudo apt-get update
-        sudo apt-get install -y git \
+        apt-get update
+        apt-get install -y git \
           cmake \
           doxygen \
           foot \
@@ -75,19 +78,19 @@ jobs:
     - name: Build documentation.
       run: cmake --build build/ --target doc
 
-#    - name: Create a tarball.
-#      run: |
-#        export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
-#        export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
-#        cmake --install build/
-#        cd "${HOME}" && tar -cvf "${HOME}/wlmaker-head.tar" wlmaker
-#
-#    - name: Upload the tarball.
-#      uses: actions/upload-artifact@v2
-#      with:
-#        name: wlmaker-head
-#        # Note: Artefacts will be zipped.
-#        path: "${HOME}/wlmaker-head.tar"
+    - name: Create a tarball.
+      run: |
+        export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
+        export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
+        cmake --install build/
+        cd "${HOME}" && tar -cvf "${HOME}/wlmaker-head.tar" wlmaker
+
+    - name: Upload the tarball.
+      uses: actions/upload-artifact@v2
+      with:
+        name: wlmaker-head
+        # Note: Artefacts will be zipped.
+        path: "${HOME}/wlmaker-head.tar"
 
     - name: Run all tests
       run: |

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -89,12 +89,14 @@ jobs:
         tar -cvf wlmaker-head.tar wlmaker
         echo "Packaged."
         zip wlmaker-head.tar.zip wlmaker-head.tar
+        ls -ld wlm*
 
     - name: Upload the tarball.
       uses: actions/upload-artifact@v2
       with:
-        name: wlmaker-head
-        path: wlmaker-head.tar.zip
+        name: wlmaker-head.tar.zip
+        path: ${HOME}/wlmaker-head.tar.zip
+        if-no-files-found: error
 
     - name: Run all tests
       run: |

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -84,7 +84,8 @@ jobs:
     - name: Create the tarball.
       run: |
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
-        cmake --install ${{github.workspace}}/build
+        export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
+        cmake -DCMAKE_INSTALL_PREFIX:PATH=${{ env.INSTALL_PATH }} --install ${{github.workspace}}/build
         cd "${{ env.INSTALL_PATH }}" && tar -zcvf wlmaker-head.tar.gz wlmaker
 
     - name: Upload artifact.

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -21,8 +21,8 @@ jobs:
     steps:
     - name: Install package dependencies.
       run: |
-        sudo apt-get update
-        sudo apt-get install -y git \
+        apt-get update
+        apt-get install -y git \
           cmake \
           doxygen \
           foot \

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -56,40 +56,40 @@ jobs:
         export PKG_CONFIG_PATH="${{ env.INSTALL_PKGCONFIG_PATH }}"
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
         export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
-        (cd ${{github.workspace}}/dependencies && cmake -DCMAKE_INSTALL_PREFIX:PATH=${{ env.INSTALL_PATH }} -B build)
-        cmake --build ${{github.workspace}}/dependencies/build
+        cmake -DCMAKE_INSTALL_PREFIX:PATH=${{ env.INSTALL_PATH }} dependencies/ -B dependencies/build/
+        cmake --build dependencies/build
 
     - name: Configure wlmaker through CMake.
       run: |
         export PKG_CONFIG_PATH="${{ env.INSTALL_PKGCONFIG_PATH }}"
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
         export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
-        cmake -DCMAKE_INSTALL_PREFIX:PATH=${{ env.INSTALL_PATH }} -B ${{github.workspace}}/build
+        cmake -DCMAKE_INSTALL_PREFIX:PATH=${{ env.INSTALL_PATH }} -B build/
 
     - name: Build wlmaker.
       run: |
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
         export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
-        cmake --build ${{github.workspace}}/build
+        cmake --build build/
 
     - name: Build documentation.
-      run: cmake --build ${{github.workspace}}/build --target doc
+      run: cmake --build build/ --target doc
 
 #    - name: Create a tarball.
 #      run: |
 #        export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
 #        export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
-#        cmake --install ${{github.workspace}}/build
-#        cd "${HOME}" && tar -cvf ${{github.workspace}}/wlmaker-head.tar wlmaker
+#        cmake --install build/
+#        cd "${HOME}" && tar -cvf "${HOME}/wlmaker-head.tar" wlmaker
 #
 #    - name: Upload the tarball.
 #      uses: actions/upload-artifact@v2
 #      with:
 #        name: wlmaker-head
 #        # Note: Artefacts will be zipped.
-#        path: ${{github.workspace}}/wlmaker-head.tar
+#        path: "${HOME}/wlmaker-head.tar"
 
     - name: Run all tests
       run: |
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
-        ctest --test-dir ${{github.workspace}}/build --build-run-dir ${{github.workspace}}/build -V
+        ctest --test-dir build/ --build-run-dir build/ -V

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -65,7 +65,7 @@ jobs:
         export PKG_CONFIG_PATH="${{ env.INSTALL_PKGCONFIG_PATH }}"
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
         export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
-        cmake -B ${{github.workspace}}/build
+        cmake -DCMAKE_INSTALL_PREFIX:PATH=${{ env.INSTALL_PATH }} -B ${{github.workspace}}/build
 
     - name: Build wlmaker.
       # Build your program with the given configuration

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -7,9 +7,9 @@ on:
     branches: [ "main", "workflow" ]
 
 env:
-  INSTALL_PATH: "${HOME}/.local"
-  INSTALL_LIBRARY_PATH: "${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
-  INSTALL_PKGCONFIG_PATH: "${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/pkgconfig/:${HOME}/.local/share/pkgconfig/"
+  INSTALL_PATH: "${HOME}/wlmaker"
+  INSTALL_LIBRARY_PATH: "${HOME}/wlmaker/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+  INSTALL_PKGCONFIG_PATH: "${HOME}/wlmaker/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/pkgconfig/:${HOME}/wlmaker/share/pkgconfig/"
 
 jobs:
   build:
@@ -77,6 +77,18 @@ jobs:
 
     - name: Build documentation.
       run: cmake --build ${{github.workspace}}/build --target doc
+
+    - name: Create the tarball.
+      run: |
+        export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
+        cmake --install ${{github.workspace}}/build
+        cd "${{ env.INSTALL_PATH }}" && tar -zcvf wlmaker-head.tar.gz wlmaker
+
+    - name: Upload artifact.
+      uses: actions/upload-artifact@v2
+      with:
+        name: wlmaker
+        path: wlmaker-head.tar.gz
 
 #    - name: Run all tests
 #      working-directory: ${{github.workspace}}/build

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -2,9 +2,9 @@ name: Build for Linux
 
 on:
   push:
-    branches: [ "main", "workflow" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "workflow" ]
+    branches: [ "main" ]
 
 env:
   INSTALL_PATH: "${HOME}/wlmaker"
@@ -15,14 +15,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    container:
-      image: debian:bookworm
-      
     steps:
     - name: Install package dependencies.
       run: |
-        apt-get update
-        apt-get install -y git \
+        sudo apt-get update
+        sudo apt-get install -y git \
           cmake \
           doxygen \
           foot \
@@ -78,25 +75,6 @@ jobs:
 
     - name: Build documentation.
       run: cmake --build build/ --target doc
-
-    - name: Create a tarball.
-      run: |
-        export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
-        export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
-        cmake --install build/
-        echo "Packaging from ${HOME}..."
-        cd ${HOME}
-        tar -cvf wlmaker-head.tar wlmaker
-        echo "Packaged, to ${{ github.workspace}}."
-        zip wlmaker-head.tar.zip wlmaker-head.tar
-        ls -ld wlm*
-
-    - name: Upload the tarball.
-      uses: actions/upload-artifact@v4
-      with:
-        name: wlmaker-head
-        path: ${{ github.workspace }}/wlmaker-head.tar.zip
-        if-no-files-found: error
 
     - name: Run all tests
       run: |

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -93,7 +93,7 @@ jobs:
       with:
         name: wlmaker-head
         # Note: Artefacts will be zipped.
-        path: wlmaker-head.tar.zip
+        path: wlmaker-head.tar
 
     - name: Run all tests
       run: |

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -84,8 +84,7 @@ jobs:
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
         export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
         cmake --install build/
-        tar -cvf wlmaker-head.tar wlmaker
-        echo "Packaging..."
+        echo "Packaging from ${HOME}..."
         cd ${HOME}
         tar -cvf wlmaker-head.tar wlmaker
         echo "Packaged."

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -94,8 +94,8 @@ jobs:
     - name: Upload the tarball.
       uses: actions/upload-artifact@v2
       with:
-        name: wlmaker-head.tar.zip
-        path: ${HOME}/wlmaker-head.tar.zip
+        name: wlmaker-head
+        path: wlmaker-head.tar.zip
         if-no-files-found: error
 
     - name: Run all tests

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -82,13 +82,13 @@ jobs:
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
         export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
         cmake --install ${{github.workspace}}/build
-        cd "${HOME}" && tar -zcvf wlmaker-head.tar.gz wlmaker
+        cd "${HOME}" && tar -zcvf ${{github.workspace}}/wlmaker-head.tar.gz wlmaker
 
     - name: Upload artifact.
       uses: actions/upload-artifact@v2
       with:
         name: wlmaker
-        path: wlmaker-head.tar.gz
+        path: ${{github.workspace}}/wlmaker-head.tar.gz
 
 #    - name: Run all tests
 #      working-directory: ${{github.workspace}}/build

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -2,9 +2,9 @@ name: Build for Linux
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "workflow" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "workflow" ]
 
 env:
   INSTALL_PATH: "${HOME}/.local"
@@ -18,6 +18,7 @@ jobs:
     steps:
     - name: Install package dependencies.
       run: |
+        sudo apt-get update
         sudo apt-get install -y git \
           cmake \
           doxygen \

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -84,14 +84,16 @@ jobs:
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
         export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
         cmake --install build/
+        echo "Packaging: cd ${HOME} && tar -cvf ${HOME}/wlmaker-head.tar wlmaker"
         cd "${HOME}" && tar -cvf "${HOME}/wlmaker-head.tar" wlmaker
+        echo "Packaged."
 
     - name: Upload the tarball.
       uses: actions/upload-artifact@v2
       with:
         name: wlmaker-head
         # Note: Artefacts will be zipped.
-        path: "${HOME}/wlmaker-head.tar"
+        path: wlmaker-head.tar.zip
 
     - name: Run all tests
       run: |

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -44,6 +44,7 @@ jobs:
           libxcb-res0-dev \
           libxcb-xinput-dev \
           libxkbcommon-dev \
+          libxml2-dev \
           meson \
           plantuml \
           xmlto \

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -15,6 +15,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    container:
+      image: debian:bookworm
+      
     steps:
     - name: Install package dependencies.
       run: |
@@ -60,7 +63,6 @@ jobs:
         cmake --build ${{github.workspace}}/dependencies/build
 
     - name: Configure wlmaker through CMake.
-      # Configure CMake in a 'build' subdirectory.
       run: |
         export PKG_CONFIG_PATH="${{ env.INSTALL_PKGCONFIG_PATH }}"
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
@@ -68,7 +70,6 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX:PATH=${{ env.INSTALL_PATH }} -B ${{github.workspace}}/build
 
     - name: Build wlmaker.
-      # Build your program with the given configuration
       run: |
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
         export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
@@ -77,25 +78,21 @@ jobs:
     - name: Build documentation.
       run: cmake --build ${{github.workspace}}/build --target doc
 
-    - name: Create the tarball.
+    - name: Create a tarball.
       run: |
         export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
         export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
         cmake --install ${{github.workspace}}/build
-        cd "${HOME}" && tar -zcvf ${{github.workspace}}/wlmaker-head.tar.gz wlmaker
+        cd "${HOME}" && tar -cvf ${{github.workspace}}/wlmaker-head.tar wlmaker
 
-    - name: Upload artifact.
+    - name: Upload the tarball.
       uses: actions/upload-artifact@v2
       with:
-        name: wlmaker
-        path: ${{github.workspace}}/wlmaker-head.tar.gz
+        name: wlmaker-head
+        # Note: Artefacts will be zipped.
+        path: ${{github.workspace}}/wlmaker-head.tar
 
-#    - name: Run all tests
-#      working-directory: ${{github.workspace}}/build
-#      # Execute tests defined by the CMake configuration.
-#      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-#      run: |
-#        export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
-#        #ctest --test-dir ${{github.workspace}}/build
-#        ${{github.workspace}}/build/src/toolkit/toolkit_test
-
+    - name: Run all tests
+      run: |
+        export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
+        ctest --test-dir ${{github.workspace}}/build --build-run-dir ${{github.workspace}}/build -V

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -15,14 +15,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    container:
-      image: debian:bookworm
-      
     steps:
     - name: Install package dependencies.
       run: |
-        apt-get update
-        apt-get install -y git \
+        sudo apt-get update
+        sudo apt-get install -y git \
           cmake \
           doxygen \
           foot \
@@ -78,19 +75,19 @@ jobs:
     - name: Build documentation.
       run: cmake --build ${{github.workspace}}/build --target doc
 
-    - name: Create a tarball.
-      run: |
-        export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
-        export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
-        cmake --install ${{github.workspace}}/build
-        cd "${HOME}" && tar -cvf ${{github.workspace}}/wlmaker-head.tar wlmaker
-
-    - name: Upload the tarball.
-      uses: actions/upload-artifact@v2
-      with:
-        name: wlmaker-head
-        # Note: Artefacts will be zipped.
-        path: ${{github.workspace}}/wlmaker-head.tar
+#    - name: Create a tarball.
+#      run: |
+#        export LD_LIBRARY_PATH="${{ env.INSTALL_LIBRARY_PATH }}"
+#        export PATH="${PATH}:${{ env.INSTALL_PATH }}/bin"
+#        cmake --install ${{github.workspace}}/build
+#        cd "${HOME}" && tar -cvf ${{github.workspace}}/wlmaker-head.tar wlmaker
+#
+#    - name: Upload the tarball.
+#      uses: actions/upload-artifact@v2
+#      with:
+#        name: wlmaker-head
+#        # Note: Artefacts will be zipped.
+#        path: ${{github.workspace}}/wlmaker-head.tar
 
     - name: Run all tests
       run: |

--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -44,8 +44,7 @@ jobs:
           meson \
           plantuml \
           xmlto \
-          xsltproc \
-          wayland-protocols
+          xsltproc
     
     - name: Checkout code including submodule dependencies.
       uses: actions/checkout@v3


### PR DESCRIPTION
Cleans up the build workflow and runs all the tests, addressing #3.

Doesn't create a binary package of what was built; but just a zip or tarball won't easily be re-usable across binaries. A flatpak would be a better approach, there.