### PR TITLE
Disables unused variable warning, happening on recent clang with not-that-recent bison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 **/CMakeFiles/*
 **/CMakeCache.txt
 **/build/*
+**/build-clang/*
 TAGS
 cscope.files
 cscope.in.out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@
 #
 # Default arguments:
 # cmake -DCMAKE_INSTALL_PREFIX:PATH=${HOME}/.local -Dconfig_DOXYGEN_CRITICAL=ON -B build
+# CC=clang cmake -DCMAKE_INSTALL_PREFIX:PATH=${HOME}/.local -Dconfig_DOXYGEN_CRITICAL=ON -B build-clang
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.13)
 PROJECT(wlmaker VERSION 0.1

--- a/src/conf/CMakeLists.txt
+++ b/src/conf/CMakeLists.txt
@@ -37,6 +37,9 @@ TARGET_SOURCES(conf PRIVATE
   ${CMAKE_CURRENT_BINARY_DIR}/analyzer.c
   ${CMAKE_CURRENT_BINARY_DIR}/grammar.c)
 TARGET_INCLUDE_DIRECTORIES(conf PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/)
+# TODO(kaeser@gubbe.ch):Remove, once updating post bison 3.8.2 (Aug 2022).
+# See: https://github.com/phkaeser/wlmaker/issues/53
+TARGET_COMPILE_OPTIONS(conf PRIVATE -Wno-unused-but-set-variable)
 TARGET_LINK_LIBRARIES(conf base)
 
 ADD_EXECUTABLE(conf_test conf_test.c)


### PR DESCRIPTION
Works around #53 . 

This is a workaround for an upstream bug that appears fixed, should revert once toolchain catches up.