### PR TITLE
Improves documentation for build, install, running & configuring.

### DIFF
--- a/.github/workflows/build-for-linux.yml
+++ b/.github/workflows/build-for-linux.yml
@@ -24,13 +24,14 @@ jobs:
     - name: Install package dependencies.
       run: |
         apt-get update
-        apt-get install -y git \
+        apt-get install -y \
           bison \
           clang \
           cmake \
           doxygen \
           flex \
           foot \
+          git \
           glslang-dev \
           glslang-tools \
           graphviz \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Wayland Maker is in early development stage. Highlights for current version (0.2
 * Appearance matches Window Maker: Decorations, dock, clip.
 * Support for Wayland XDG shell (mostly complete. Bug reports welcome).
 * Initial support for X11 applications (positioning and specific modes are missing).
-  Use `--start_xwayland` option to enable XWayland, it's off by default.
+  Use `--start_xwayland` argument to enable XWayland, it's off by default.
 * Appearance, workspaces, dock, keyboard: All hardcoded.
 * A prototype DockApp (`apps/wlmclock`).
 

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Protocol support:
 
 ### Build & use it!
 
-* From source: Please follow the [detailled build instructions][doc/BUILD.md]
+* From source: Please follow the [detailled build instructions](doc/BUILD.md)
   for a step-by-step guide. 
   
-* Once compiled, see the [these instructions][doc/RUN.md] on how to run
+* Once compiled, see the [these instructions](doc/RUN.md) on how to run
   Wayland Maker in a window or standalone.
 
 [!NOTE]

--- a/README.md
+++ b/README.md
@@ -31,46 +31,21 @@ Protocol support:
 * `xdg-shell`: Largely implemented & tested.
 * `idle-inhibit-unstable-v1`: Implemented, untested.
 
-### To configure
+### Build & use it!
 
-Some of Wayland Maker's core dependencies are also in development and are a
-moving target, hence these are referred to as git submodules. Build and install
-these first (default to `${HOME}/.local`):
+* From source: Please follow the [detailled build instructions][doc/BUILD.md]
+  for a step-by-step guide. 
+  
+* Once compiled, see the [these instructions][doc/RUN.md] on how to run
+  Wayland Maker in a window or standalone.
 
-``` bash
-git submodule update --init --checkout --recursive --merge
-(cd dependencies &&
- LD_LIBRARY_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
- PKG_CONFIG_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/pkgconfig/:${HOME}/.local/share/pkgconfig/" \
- cmake -DCMAKE_INSTALL_PREFIX:PATH=${HOME}/.local -B build &&
- cd build &&
- LD_LIBRARY_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
- PKG_CONFIG_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/pkgconfig/:${HOME}/.local/share/pkgconfig/" \
- make)
-```
+[!NOTE]
+`wlmaker` is still in early development, so it's not recommended to use it as
+your primary compositor.
 
-With the dependencies installed, proceed to configure wlmaker:
 
-```bash
-LD_LIBRARY_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
-PKG_CONFIG_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/pkgconfig/:${HOME}/.local/share/pkgconfig/" \
-cmake -DCMAKE_INSTALL_PREFIX="${HOME}/.local" -B build/
-```
 
-### To build and install
-
-``` bash
-(cd build && \
- LD_LIBRARY_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
- PKG_CONFIG_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/pkgconfig/:${HOME}/.local/share/pkgconfig/" \
- make && \
- make install)
-```
-
-### To run it
-
-Since `wlmaker` is in early development, it's not recommended to use it as your
-primary compositor. It should run fine in it's own window, though:
+It should run fine in it's own window, though:
 
 ```bash
 LD_LIBRARY_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wlmaker - Wayland Maker
 
-A [Wayland](https://wayland.freedesktop.org/) compositor inspired by 
+A [Wayland](https://wayland.freedesktop.org/) compositor inspired by
 [Window Maker](https://www.windowmaker.org/).
 
 Key features:
@@ -34,31 +34,19 @@ Protocol support:
 ### Build & use it!
 
 * From source: Please follow the [detailled build instructions](doc/BUILD.md)
-  for a step-by-step guide. 
-  
+  for a step-by-step guide.
+
 * Once compiled, see the [these instructions](doc/RUN.md) on how to run
-  Wayland Maker in a window or standalone.
+  Wayland Maker in a window or standalone, and to configure it for your needs.
 
-[!NOTE]
-`wlmaker` is still in early development, so it's not recommended to use it as
-your primary compositor.
-
-
-
-It should run fine in it's own window, though:
-
-```bash
-LD_LIBRARY_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
-PKG_CONFIG_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/pkgconfig/:${HOME}/.local/share/pkgconfig/" \
-${HOME}/.local/bin/wlmaker
-```
-
-Press `ctrl+window+alt T` to open a Terminal (`foot`), and `ctrl-window-alt Q`
-to exit.
+> [!NOTE]
+> `wlmaker` is still in early development, so it's not recommended to use it as
+> your primary compositor.
 
 ## Contributing
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for details, and 
+Contributions and help are highly welcome! See
+[`CONTRIBUTING.md`](CONTRIBUTING.md) for details, and
 [code of conduct](CODE_OF_CONDUCT.md) for more.
 
 ## License

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -1,0 +1,101 @@
+# Build Wayland Maker
+
+## Install required packages
+
+Wayland Maker is developed and tested on Debian, hence we're using package
+names and versions as found on that distribution. You need to run:
+
+```
+apt-get install -y \
+  bison \
+  clang \
+  cmake \
+  doxygen \
+  flex \
+  foot \
+  git \
+  glslang-dev \
+  glslang-tools \
+  graphviz \
+  libcairo2-dev \
+  libgbm-dev \
+  libinput-dev \
+  libncurses-dev \
+  libudev-dev \
+  libvulkan-dev \
+  libwayland-dev \
+  libxcb-composite0-dev \
+  libxcb-dri3-dev \
+  libxcb-ewmh-dev \
+  libxcb-icccm4-dev \
+  libxcb-present-dev \
+  libxcb-render-util0-dev \
+  libxcb-res0-dev \
+  libxcb-xinput-dev \
+  libxkbcommon-dev \
+  libxml2-dev \
+  meson \
+  plantuml \
+  wayland-protocols \
+  xmlto \
+  xsltproc \
+  xwayland
+```
+
+See the [github build workflow](../.github/workflows/build-for-linux.yml) as reference.
+
+## Get Wayland Maker
+
+```
+git clone https://github.com/phkaeser/wlmaker.git
+```
+
+Run the commands below from the directory you cloned the source into.
+
+## Get, build and install dependencies
+
+Wayland Maker is still in development and is depending on a set of rapidly
+evolving libraries. To keep the API between code and dependencies synchronized,
+some dependencies are included as github submodules. Here's how to configure 
+and build these.
+
+The dependencies will be installed to `${HOME}/.local`:
+
+``` bash
+git submodule update --init --checkout --recursive --merge
+(cd dependencies &&
+ LD_LIBRARY_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
+ PKG_CONFIG_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/pkgconfig/:${HOME}/.local/share/pkgconfig/" \
+ cmake -DCMAKE_INSTALL_PREFIX:PATH=${HOME}/.local -B build &&
+ cd build &&
+ LD_LIBRARY_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
+ PKG_CONFIG_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/pkgconfig/:${HOME}/.local/share/pkgconfig/" \
+ make)
+```
+
+## Configure, build and install Wayland Maker
+
+```bash
+LD_LIBRARY_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
+PKG_CONFIG_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/pkgconfig/:${HOME}/.local/share/pkgconfig/" \
+cmake -DCMAKE_INSTALL_PREFIX="${HOME}/.local" -B build/
+```
+
+``` bash
+(cd build && \
+ LD_LIBRARY_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
+ PKG_CONFIG_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/pkgconfig/:${HOME}/.local/share/pkgconfig/" \
+ make && \
+ make install)
+```
+
+Now you have an installed binary, and can run it with the appropriate
+environment. See [running instructions][RUN.md] for more details.
+
+```bash
+LD_LIBRARY_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
+PKG_CONFIG_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/pkgconfig/:${HOME}/.local/share/pkgconfig/" \
+${HOME}/.local/bin/wlmaker
+```
+
+Please report if something doesn´t work for you.

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -56,7 +56,7 @@ Run the commands below from the directory you cloned the source into.
 
 Wayland Maker is still in development and is depending on a set of rapidly
 evolving libraries. To keep the API between code and dependencies synchronized,
-some dependencies are included as github submodules. Here's how to configure 
+some dependencies are included as github submodules. Here's how to configure
 and build these.
 
 The dependencies will be installed to `${HOME}/.local`:

--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -90,7 +90,7 @@ cmake -DCMAKE_INSTALL_PREFIX="${HOME}/.local" -B build/
 ```
 
 Now you have an installed binary, and can run it with the appropriate
-environment. See [running instructions][RUN.md] for more details.
+environment. See [running instructions](RUN.md) for more details.
 
 ```bash
 LD_LIBRARY_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \

--- a/doc/RUN.md
+++ b/doc/RUN.md
@@ -1,6 +1,6 @@
 # Running Wayland Maker
 
-If not done yet, please follow the [detailled build instructions][BUILD.md] to
+If not done yet, please follow the [detailled build instructions](BUILD.md) to
 build and install from source.
 
 The commands below assume that dependencies and `wlmaker` were installed to

--- a/doc/RUN.md
+++ b/doc/RUN.md
@@ -9,14 +9,36 @@ The commands below assume that dependencies and `wlmaker` were installed to
 Once running: Press `Ctrl-Window-Alt+T` to open a terminal (`foot`), or
 `Ctrl-Window-Alt+Q` to exit.
 
-## Option 1: Run as window
+## Option 1: Run in a window
 
-The most accessible option is to run Wayland Maker as a window, in your 
-already-running graphical environment. It can run both as a window on a X11
-or a Wayland session. To run:
+The most accessible option is to run Wayland Maker in a window in your
+already-running graphical environment. It can run both on a X11 or a Wayland
+session. To run:
 
 ```bash
 LD_LIBRARY_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
 PKG_CONFIG_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/pkgconfig/:${HOME}/.local/share/pkgconfig/" \
 ${HOME}/.local/bin/wlmaker
 ```
+
+
+## Make it run for you!
+
+* [etc/wlmaker.plist](../etc/wlmaker.plist) is the where keyboard options, key
+  bindings, screensaver details and more can be configured. The file in the
+  source tree is the compiled-in default.
+
+  To extend: Create a copy of the file, modify it suitably, and pass to
+  `wlmaker` via the `--config_file=...` arugment.
+
+* To run X11 applications in Wayland Maker, XWayland must be enabled. It is
+  compiled in, if the `xwayland` package is installed. In that case, use the
+  `--start_xwayland` option. The `DISPLAY` environment variable will be set
+  suitably.
+
+* [etc/style-default.plist](../etc/style-default.plist) is the compiled-in
+  default theme. With [etc/style-debian.plist](../etc/style-debian.plist),
+  there is an alternative theme you can use -- or extend it on your own.
+
+  Run `wlmaker` with `--style_file=...` to use an alternative style.
+

--- a/doc/RUN.md
+++ b/doc/RUN.md
@@ -1,0 +1,22 @@
+# Running Wayland Maker
+
+If not done yet, please follow the [detailled build instructions][BUILD.md] to
+build and install from source.
+
+The commands below assume that dependencies and `wlmaker` were installed to
+`${HOME}/.local`
+
+Once running: Press `Ctrl-Window-Alt+T` to open a terminal (`foot`), or
+`Ctrl-Window-Alt+Q` to exit.
+
+## Option 1: Run as window
+
+The most accessible option is to run Wayland Maker as a window, in your 
+already-running graphical environment. It can run both as a window on a X11
+or a Wayland session. To run:
+
+```bash
+LD_LIBRARY_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)" \
+PKG_CONFIG_PATH="${HOME}/.local/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/pkgconfig/:${HOME}/.local/share/pkgconfig/" \
+${HOME}/.local/bin/wlmaker
+```


### PR DESCRIPTION
So far, only the "run in a window" mode is documented. Have to first verify what's needed for standalone. Addresses parts of #73 .