### PR TITLE
Adds --width and --height commandline arguments.

### DIFF
--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -222,8 +222,8 @@ Support for visual effects to improve usability, but not for pure show.
 * Support different output scale & transformations
   * [done] Add a style file that has dimensions suitably for a Hi-Res screen (eg. Retina) (#99)
   * [done] Scale icons to tile size.
-  * Add commandline arguments to configure size of window (#98)
-  * Add option to specify an output transformation (#97)
+  * [done] Add option to specify an output transformation (#97). Note: Will not work well in X11 window mode.
+  * [done] Add commandline arguments to configure size of window (#98)
 
 * Misc
   * [done] Expose the decoration manager configurables through the config file.

--- a/etc/wlmaker.plist
+++ b/etc/wlmaker.plist
@@ -44,4 +44,7 @@
   Autostart = (
     "/usr/bin/foot"
   );
+  Output = {
+    Transformation = Normal;
+  };
 }

--- a/src/output.c
+++ b/src/output.c
@@ -27,6 +27,11 @@
 
 #include <libbase/libbase.h>
 
+/// Use wlroots non-stable API.
+#define WLR_USE_UNSTABLE
+#include <wlr/backend/x11.h>
+#undef WLR_USE_UNSTABLE
+
 /* == Declarations ========================================================= */
 
 static void handle_output_destroy(struct wl_listener *listener_ptr,
@@ -70,6 +75,8 @@ wlmaker_output_t *wlmaker_output_create(
     struct wlr_allocator *wlr_allocator_ptr,
     struct wlr_renderer *wlr_renderer_ptr,
     struct wlr_scene *wlr_scene_ptr,
+    uint32_t width,
+    uint32_t height,
     wlmaker_server_t *server_ptr)
 {
     wlmaker_output_t *output_ptr = logged_calloc(1, sizeof(wlmaker_output_t));
@@ -128,6 +135,20 @@ wlmaker_output_t *wlmaker_output_create(
     struct wlr_output_state state;
     wlr_output_state_init(&state);
     wlr_output_state_set_enabled(&state, true);
+
+    // Issue #97: Found that X11 and transformations do not translate
+    // cursor coordinates well. Force it to 'Normal'.
+    if (wlr_output_is_x11(wlr_output_ptr) &&
+        output_ptr->transformation != WL_OUTPUT_TRANSFORM_NORMAL) {
+        const char *name_ptr = "Unknown";
+        wlmcfg_enum_value_to_name(
+            _wlmaker_output_transformation_desc,
+            output_ptr->transformation,
+            &name_ptr);
+        bs_log(BS_WARNING, "Found X11 backend with Output.Transformation "
+               "'%s'. Overriding to 'Normal'.", name_ptr);
+        output_ptr->transformation = WL_OUTPUT_TRANSFORM_NORMAL;
+    }
     wlr_output_state_set_transform(&state, output_ptr->transformation);
 
     // Set modes for backends that have them.
@@ -140,6 +161,12 @@ wlmaker_output_t *wlmaker_output_create(
     } else {
         bs_log(BS_INFO, "No modes available on %s",
                output_ptr->wlr_output_ptr->name);
+    }
+
+    if (wlr_output_is_x11(wlr_output_ptr) && 0 < width && 0 < height) {
+        bs_log(BS_INFO, "Overriding output dimensions to %"PRIu32"x%"PRIu32,
+               width, height);
+        wlr_output_state_set_custom_mode(&state, width, height, 0);
     }
 
     if (!wlr_output_test_state(output_ptr->wlr_output_ptr, &state)) {

--- a/src/output.h
+++ b/src/output.h
@@ -71,6 +71,8 @@ struct _wlmaker_output_t {
  * @param wlr_allocator_ptr
  * @param wlr_renderer_ptr
  * @param wlr_scene_ptr
+ * @param width
+ * @param height
  * @param server_ptr
  *
  * @return The output device handle or NULL on error.
@@ -80,6 +82,8 @@ wlmaker_output_t *wlmaker_output_create(
     struct wlr_allocator *wlr_allocator_ptr,
     struct wlr_renderer *wlr_renderer_ptr,
     struct wlr_scene *wlr_scene_ptr,
+    uint32_t width,
+    uint32_t height,
     wlmaker_server_t *server_ptr);
 
 /**

--- a/src/output.h
+++ b/src/output.h
@@ -59,6 +59,9 @@ struct _wlmaker_output_t {
     struct wl_listener        output_frame_listener;
     /** Listener for `request_state` signals raised by `wlr_output`. */
     struct wl_listener        output_request_state_listener;
+
+    /** Default transformation for the output(s). */
+    enum wl_output_transform  transformation;
 };
 
 /**

--- a/src/server.c
+++ b/src/server.c
@@ -596,6 +596,8 @@ void handle_new_output(struct wl_listener *listener_ptr, void *data_ptr)
         server_ptr->wlr_allocator_ptr,
         server_ptr->wlr_renderer_ptr,
         server_ptr->wlr_scene_ptr,
+        server_ptr->options_ptr->width,
+        server_ptr->options_ptr->height,
         server_ptr);
     if (NULL == output_ptr) {
         bs_log(BS_INFO, "Failed wlmaker_output_create for server %p",

--- a/src/server.h
+++ b/src/server.h
@@ -78,6 +78,10 @@ extern "C" {
 typedef struct {
     /** Whether to start XWayland. */
     bool                      start_xwayland;
+    /** Preferred output height, for windowed mode. */
+    uint32_t                  height;
+    /** Preferred output width, for windowed mode. */
+    uint32_t                  width;
 } wlmaker_server_options_t;
 
 /** State of the Wayland server. */

--- a/src/wlmaker.c
+++ b/src/wlmaker.c
@@ -48,13 +48,13 @@ static char *wlmaker_arg_config_file_ptr = NULL;
 static char *wlmaker_arg_state_file_ptr = NULL;
 /** Will hold the value of --style_file. */
 static char *wlmaker_arg_style_file_ptr = NULL;
-/** Will hold the value of --height. */
-static uint32_t wlmaker_arg_height = 0;
-/** Will hold the value of --width. */
-static uint32_t wlmaker_arg_width = 0;
 
 /** Startup options for the server. */
-static wlmaker_server_options_t wlmaker_server_options = {};
+static wlmaker_server_options_t wlmaker_server_options = {
+    .start_xwayland = false,
+    .height = 0,
+    .width = 0,
+};
 
 /** Log levels. */
 static const bs_arg_enum_table_t wlmaker_log_levels[] = {
@@ -106,14 +106,14 @@ static const bs_arg_t wlmaker_args[] = {
         "only if --width is set, too. Set to 0 for using the output's "
         "preferred dimensions.",
         0, 0, UINT32_MAX,
-        &wlmaker_arg_height),
+        &wlmaker_server_options.height),
     BS_ARG_UINT32(
         "width",
         "Desired output width. Applies when running in windowed mode, and "
         "only if --height is set, too. Set to 0 for using the output's "
         "preferred dimensions.",
         0, 0, UINT32_MAX,
-        &wlmaker_arg_width),
+        &wlmaker_server_options.width),
     BS_ARG_SENTINEL()
 };
 

--- a/src/wlmaker.c
+++ b/src/wlmaker.c
@@ -48,6 +48,10 @@ static char *wlmaker_arg_config_file_ptr = NULL;
 static char *wlmaker_arg_state_file_ptr = NULL;
 /** Will hold the value of --style_file. */
 static char *wlmaker_arg_style_file_ptr = NULL;
+/** Will hold the value of --height. */
+static uint32_t wlmaker_arg_height = 0;
+/** Will hold the value of --width. */
+static uint32_t wlmaker_arg_width = 0;
 
 /** Startup options for the server. */
 static wlmaker_server_options_t wlmaker_server_options = {};
@@ -96,6 +100,20 @@ static const bs_arg_t wlmaker_args[] = {
         "INFO",
         &wlmaker_log_levels[0],
         (int*)&bs_log_severity),
+    BS_ARG_UINT32(
+        "height",
+        "Desired output height. Applies when running in windowed mode, and "
+        "only if --width is set, too. Set to 0 for using the output's "
+        "preferred dimensions.",
+        0, 0, UINT32_MAX,
+        &wlmaker_arg_height),
+    BS_ARG_UINT32(
+        "width",
+        "Desired output width. Applies when running in windowed mode, and "
+        "only if --height is set, too. Set to 0 for using the output's "
+        "preferred dimensions.",
+        0, 0, UINT32_MAX,
+        &wlmaker_arg_width),
     BS_ARG_SENTINEL()
 };
 


### PR DESCRIPTION
Addresses the gist of #98, at least when running as X11 window.

Additionally, it enforces `Normal` transformation on X11 windows, since the cursor position is not handled correctly by wlroots otherwise (#97).