### PR TITLE
Permits scaling the output through a config file setting.

### DIFF
--- a/doc/RUN.md
+++ b/doc/RUN.md
@@ -66,9 +66,13 @@ The desktop entry will execute `${HOME}/.local/bin/wrap-wlmaker.sh`.
 
   Run `wlmaker` with `--style_file=...` to use an alternative style.
 
-* As of now, Wayland Maker does not (yet) support scaling outputs. As a
-  workaround, you can configure the style with larger decorations & fonts,
-  as is done in [etc/style-debian.plist](../etc/style-debian.plist).
+* To make Wayland Maker look well on a high-resolution screen, you can either
+  set the `Output` `Scale` in [etc/wlmaker.plist](../etc/wlmaker.plist) (and
+  use `--config_file=...`). This will scale all surfaces.
+
+  Or, you can configure the style with larger decorations & fonts, as is done
+  in [etc/style-debian.plist](../etc/style-debian.plist). This will not scale
+  application surfaces.
 
 # Debugging issues
 

--- a/etc/wlmaker.plist
+++ b/etc/wlmaker.plist
@@ -46,5 +46,6 @@
   );
   Output = {
     Transformation = Normal;
+    Scale = 1.0;
   };
 }

--- a/src/conf/decode.c
+++ b/src/conf/decode.c
@@ -365,31 +365,6 @@ bool _wlmcfg_decode_int64(wlmcfg_object_t *obj_ptr, int64_t *int64_ptr)
     return bs_strconvert_int64(value_ptr, int64_ptr, 10);
 }
 
-
-#include <errno.h>
-#include <ctype.h>
-bool bs_strconvert_double(
-    const char *string_ptr,
-    double *value_ptr)
-{
-    char *invalid_ptr = NULL;
-    errno = 0;
-    double tmp_value = strtod(string_ptr, &invalid_ptr);
-    if (0 != errno) {
-        bs_log(BS_ERROR | BS_ERRNO, "Failed strtod(\"%s\", %p)",
-               string_ptr, &invalid_ptr);
-        return false;
-    }
-    if ('\0' != *invalid_ptr && !isspace(*invalid_ptr)) {
-        bs_log(BS_ERROR, "Failed strtod(\"%s\", %p) at \"%s\"",
-               string_ptr, &invalid_ptr, invalid_ptr);
-        return false;
-    }
-
-    *value_ptr = tmp_value;
-    return true;
-}
-
 /* ------------------------------------------------------------------------- */
 /** Decodes a floating point number. */
 bool _wlmcfg_decode_double(wlmcfg_object_t *obj_ptr, double *double_ptr)

--- a/src/conf/decode.h
+++ b/src/conf/decode.h
@@ -55,6 +55,7 @@ typedef struct {
 typedef enum {
     WLMCFG_TYPE_UINT64,
     WLMCFG_TYPE_INT64,
+    WLMCFG_TYPE_DOUBLE,
     WLMCFG_TYPE_ARGB32,
     WLMCFG_TYPE_BOOL,
     WLMCFG_TYPE_ENUM,
@@ -75,6 +76,12 @@ typedef struct {
     /** The default value, if not in the dict. */
     uint64_t                   default_value;
 } wlmcfg_desc_uint64_t;
+
+/** A floating point value. */
+typedef struct {
+    /** The default value, if not in the dict. */
+    double                    default_value;
+} wlmcfg_desc_double_t;
 
 /** A color, encoded as string in format 'argb32:aarrggbb'. */
 typedef struct {
@@ -134,6 +141,7 @@ struct _wlmcfg_desc_t {
     union {
         wlmcfg_desc_int64_t   v_int64;
         wlmcfg_desc_uint64_t  v_uint64;
+        wlmcfg_desc_double_t  v_double;
         wlmcfg_desc_argb32_t  v_argb32;
         wlmcfg_desc_bool_t    v_bool;
         wlmcfg_desc_enum_t    v_enum;
@@ -163,6 +171,15 @@ struct _wlmcfg_desc_t {
         .required = _required,                                          \
         .field_offset = offsetof(_base, _field),                        \
         .v.v_int64.default_value = _default                             \
+    }
+
+/** Descriptor for a floating point value. */
+#define WLMCFG_DESC_DOUBLE(_key, _required, _base, _field, _default) {  \
+        .type = WLMCFG_TYPE_DOUBLE,                                     \
+        .key_ptr = (_key),                                              \
+        .required = _required,                                          \
+        .field_offset = offsetof(_base, _field),                        \
+        .v.v_double.default_value = _default                            \
     }
 
 /** Descriptor for an ARGB32 value. */

--- a/src/output.c
+++ b/src/output.c
@@ -59,6 +59,7 @@ static const wlmcfg_desc_t _wlmaker_output_config_desc[] = {
     WLMCFG_DESC_ENUM("Transformation", true, wlmaker_output_t, transformation,
                      WL_OUTPUT_TRANSFORM_NORMAL,
                      _wlmaker_output_transformation_desc),
+    WLMCFG_DESC_DOUBLE("Scale", true, wlmaker_output_t, scale, 1.0),
     WLMCFG_DESC_SENTINEL()
 };
 
@@ -129,6 +130,7 @@ wlmaker_output_t *wlmaker_output_create(
     wlr_output_state_init(&state);
     wlr_output_state_set_enabled(&state, true);
     wlr_output_state_set_transform(&state, output_ptr->transformation);
+    wlr_output_state_set_scale(&state, output_ptr->scale);
 
     // Set modes for backends that have them.
     if (!wl_list_empty(&output_ptr->wlr_output_ptr->modes)) {

--- a/src/output.h
+++ b/src/output.h
@@ -62,6 +62,8 @@ struct _wlmaker_output_t {
 
     /** Default transformation for the output(s). */
     enum wl_output_transform  transformation;
+    /** Default scaling factor to use for the output(s). */
+    double                    scale;
 };
 
 /**


### PR DESCRIPTION
A further addition for #99 -- the scaling setting will upscale *all* surfaces (including applications), but may look blurry.