### PR TITLE
Fixes ASSERT when running fuzzel.

### DIFF
--- a/.github/workflows/build-for-fedora41.yml
+++ b/.github/workflows/build-for-fedora41.yml
@@ -1,0 +1,56 @@
+name: Build for Fedora Linux 41
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build_matrix:
+    strategy:
+      matrix:
+        compiler: [ "gcc", "clang" ]
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:41
+
+    steps:
+    - name: Install package dependencies.
+      run: |
+        dnf -y upgrade
+        dnf -y install \
+          bison \
+          clang \
+          cmake \
+          flex \
+          gcc \
+          git \
+          cairo-devel \
+          ncurses-devel \
+          wlroots-devel \
+          pkg-config \
+          plantuml \
+          wayland-protocols-devel \
+          xwayland-run
+
+    - name: Checkout code, including git submodules.
+      uses: actions/checkout@v3
+      with:
+        # Not using 'recursive' prevents fetching extra submodules below
+        # dependencies/. These are only needed to build wlroots from source.
+        submodules: true
+
+    - name: Configure wlmaker through CMake.
+      run: |
+        export CC="${{ matrix.compiler }}"
+        cmake -B build/ -Dconfig_WERROR=ON
+
+    - name: Build wlmaker.
+      run: |
+        export CC="${{ matrix.compiler }}"
+        cmake --build build/
+
+    - name: Run all tests.
+      run: |
+        ctest --test-dir build/ --build-run-dir build/ -V

--- a/src/layer_panel.c
+++ b/src/layer_panel.c
@@ -69,9 +69,6 @@ static bool _wlmaker_layer_panel_apply_keyboard(
 static bool _wlmaker_layer_panel_apply_layer(
     wlmaker_layer_panel_t *layer_panel_ptr,
     enum zwlr_layer_shell_v1_layer zwlr_layer);
-static void _wlmaker_layer_panel_set_positioning(
-    wlmtk_panel_positioning_t *positioning_ptr,
-    const struct wlr_layer_surface_v1_state *state_ptr);
 
 static uint32_t _wlmaker_layer_panel_request_size(
     wlmtk_panel_t *panel_ptr,
@@ -138,9 +135,7 @@ wlmaker_layer_panel_t *_wlmaker_layer_panel_create_injected(
     layer_panel_ptr->wlr_layer_surface_v1_ptr = wlr_layer_surface_v1_ptr;
     layer_panel_ptr->server_ptr = server_ptr;
 
-    wlmtk_panel_positioning_t pos;
-    _wlmaker_layer_panel_set_positioning(
-        &pos, &layer_panel_ptr->wlr_layer_surface_v1_ptr->pending);
+    wlmtk_panel_positioning_t pos = {};
     if (!wlmtk_panel_init(
             &layer_panel_ptr->super_panel, &pos, server_ptr->env_ptr)) {
         _wlmaker_layer_panel_destroy(layer_panel_ptr);
@@ -186,16 +181,6 @@ wlmaker_layer_panel_t *_wlmaker_layer_panel_create_injected(
         &wlr_layer_surface_v1_ptr->events.new_popup,
         &layer_panel_ptr->new_popup_listener,
         _wlmaker_layer_panel_handle_new_popup);
-
-    if (!_wlmaker_layer_panel_apply_keyboard(
-            layer_panel_ptr,
-            wlr_layer_surface_v1_ptr->pending.keyboard_interactive) ||
-        !_wlmaker_layer_panel_apply_layer(
-            layer_panel_ptr,
-            layer_panel_ptr->wlr_layer_surface_v1_ptr->pending.layer)) {
-        _wlmaker_layer_panel_destroy(layer_panel_ptr);
-        return NULL;
-    }
 
     bs_log(BS_INFO, "Created layer panel %p with wlmtk surface %p",
            layer_panel_ptr, layer_panel_ptr->wlmtk_surface_ptr);
@@ -305,7 +290,7 @@ bool _wlmaker_layer_panel_apply_layer(
     default:
         wl_resource_post_error(
             layer_panel_ptr->wlr_layer_surface_v1_ptr->resource,
-            WL_DISPLAY_ERROR_INVALID_METHOD,
+            ZWLR_LAYER_SHELL_V1_ERROR_INVALID_LAYER,
             "Invalid value for for zwlr_layer value: %d",
             layer_panel_ptr->wlr_layer_surface_v1_ptr->pending.layer);
         return false;
@@ -330,25 +315,6 @@ bool _wlmaker_layer_panel_apply_layer(
     }
 
     return true;
-}
-
-/* ------------------------------------------------------------------------- */
-/** Updates `positioning_ptr` from the given surface state. */
-void _wlmaker_layer_panel_set_positioning(
-    wlmtk_panel_positioning_t *positioning_ptr,
-    const struct wlr_layer_surface_v1_state *state_ptr)
-{
-    positioning_ptr->anchor = state_ptr->anchor;
-
-    positioning_ptr->desired_width = state_ptr->desired_width;
-    positioning_ptr->desired_height = state_ptr->desired_height;
-
-    positioning_ptr->margin_left = state_ptr->margin.left;
-    positioning_ptr->margin_top = state_ptr->margin.top;
-    positioning_ptr->margin_right = state_ptr->margin.right;
-    positioning_ptr->margin_bottom = state_ptr->margin.bottom;
-
-    positioning_ptr->exclusive_zone = state_ptr->exclusive_zone;
 }
 
 /* ------------------------------------------------------------------------- */
@@ -384,8 +350,30 @@ void _wlmaker_layer_panel_handle_surface_commit(
     struct wlr_layer_surface_v1_state *state_ptr =
         &layer_panel_ptr->wlr_layer_surface_v1_ptr->pending;
 
-    wlmtk_panel_positioning_t pos;
-    _wlmaker_layer_panel_set_positioning(&pos, state_ptr);
+    wlmtk_panel_positioning_t pos = {
+        .anchor = state_ptr->anchor,
+        .desired_width = state_ptr->desired_width,
+        .desired_height = state_ptr->desired_height,
+
+        .margin_left = state_ptr->margin.left,
+        .margin_top = state_ptr->margin.top,
+        .margin_right = state_ptr->margin.right,
+        .margin_bottom = state_ptr->margin.bottom,
+
+        .exclusive_zone = state_ptr->exclusive_zone
+    };
+    // Sanity check position and anchor values.
+    if ((0 == pos.desired_width &&
+         0 == (pos.anchor & (WLR_EDGE_LEFT | WLR_EDGE_RIGHT))) ||
+        (0 == pos.desired_height &&
+         0 == (pos.anchor & (WLR_EDGE_TOP | WLR_EDGE_BOTTOM)))) {
+        wl_resource_post_error(
+            layer_panel_ptr->wlr_layer_surface_v1_ptr->resource,
+            ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_SIZE,
+            "Invalid size %d x %d for anchor 0x%"PRIx32,
+            pos.desired_width, pos.desired_height, pos.anchor);
+    }
+
     wlmtk_panel_commit(
         &layer_panel_ptr->super_panel,
         state_ptr->configure_serial,

--- a/src/toolkit/panel.c
+++ b/src/toolkit/panel.c
@@ -165,7 +165,6 @@ struct wlr_box wlmtk_panel_compute_dimensions(
     if (0 == dims.width) {
         // Width not given. Protocol requires the anchor to be set on left &
         // right edges, and translates to full width (minus margins).
-        BS_ASSERT(anchor & WLR_EDGE_LEFT && anchor & WLR_EDGE_RIGHT);
         dims.x = max_dims.x + margin_left;
         dims.width = max_dims.width - margin_left - margin_right;
     } else if (anchor & WLR_EDGE_LEFT && !(anchor & WLR_EDGE_RIGHT)) {
@@ -183,7 +182,6 @@ struct wlr_box wlmtk_panel_compute_dimensions(
     if (0 == dims.height) {
         // Height not given. Protocol requires the anchor to be set on top &
         // bottom edges, and translates to full height (minus margins).
-        BS_ASSERT(anchor & WLR_EDGE_TOP && anchor & WLR_EDGE_BOTTOM);
         dims.y = max_dims.y + margin_top;
         dims.height = max_dims.height - margin_top - margin_bottom;
     } else if (anchor & WLR_EDGE_TOP && !(anchor & WLR_EDGE_BOTTOM)) {


### PR DESCRIPTION
Caused by having applied layer positioning already during surface creation, rather than on surface commit. 

This fixes the ASSERT crash reported in #158, and ticks the first TODO in https://github.com/phkaeser/wlmaker/issues/158#issuecomment-2591024275.