### PR TITLE
Unbreak FreeBSD workflow after a package rename

### DIFF
--- a/.github/workflows/build-for-freebsd.yml
+++ b/.github/workflows/build-for-freebsd.yml
@@ -28,7 +28,7 @@ jobs:
             graphics/wayland \
             graphics/wayland-protocols \
             lang/gcc \
-            x11-toolkits/wlroots \
+            x11-toolkits/wlroots018 \
             x11/libxcb \
             x11/libxkbcommon
           cmake -B build/ -Dconfig_WERROR=ON

--- a/.github/workflows/build-for-freebsd.yml
+++ b/.github/workflows/build-for-freebsd.yml
@@ -17,6 +17,7 @@ jobs:
         operating_system: freebsd
         version: '14.2'
         run: |
+          sudo sed -i '' 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
           sudo pkg install -y \
             devel/bison \
             devel/cmake-core \


### PR DESCRIPTION
Similar to https://github.com/labwc/labwc/pull/2589 but wlmaker uses `/quarterly` set, so CI wouldn't be affected until around 2025-04-01.

*I put my patches here into the public domain. CLA isn't an option for me due to lacking a Google Account which cannot be signed up for via Tor. Feel free to resubmit under differnt authorship (e.g., `git commit --amend --reset-author`) in order to satisfy CLA.*