### PR TITLE
Make root menu configurable through a plist file.

### DIFF
--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -21,6 +21,11 @@ EmbedBinary_ADD_LIBRARY(
   "${CMAKE_CURRENT_SOURCE_DIR}/wlmaker.plist")
 
 EmbedBinary_ADD_LIBRARY(
+  embedded_root_menu
+  "root_menu"
+  "${CMAKE_CURRENT_SOURCE_DIR}/root-menu.plist")
+
+EmbedBinary_ADD_LIBRARY(
   embedded_state
   "default_state"
   "${CMAKE_CURRENT_SOURCE_DIR}/wlmaker-state.plist")
@@ -63,6 +68,13 @@ IF(PLDES)
     PROPERTY FAIL_REGULAR_EXPRESSION "${pldes_failure_regex}")
 
   ADD_TEST(
+    NAME root_menu_plist_test
+    COMMAND pldes "${CMAKE_CURRENT_SOURCE_DIR}/root-menu.plist")
+  SET_PROPERTY(
+    TEST root_menu_plist_test
+    PROPERTY FAIL_REGULAR_EXPRESSION "${pldes_failure_regex}")
+
+  ADD_TEST(
     NAME style_debian_plist_test
     COMMAND pldes "${CMAKE_CURRENT_SOURCE_DIR}/style-debian.plist")
   SET_PROPERTY(
@@ -76,10 +88,4 @@ IF(PLDES)
     TEST style_default_plist_test
     PROPERTY FAIL_REGULAR_EXPRESSION "${pldes_failure_regex}")
 
-  ADD_TEST(
-    NAME root_menu_plist_test
-    COMMAND pldes "${CMAKE_CURRENT_SOURCE_DIR}/root-menu.plist")
-  SET_PROPERTY(
-    TEST root_menu_plist_test
-    PROPERTY FAIL_REGULAR_EXPRESSION "${pldes_failure_regex}")
 ENDIF(PLDES)

--- a/etc/CMakeLists.txt
+++ b/etc/CMakeLists.txt
@@ -39,7 +39,7 @@ IF(PLDES)
   # Sadly, the gnustep-base plist utilies don't return EXIT_FAILURE upon
   # parsing an invalid plist file. But eg. `pldes` reports the parsing error,
   # so we capture this as a failure.
-  SET(pldes_failure_regex "pldes.*at\ line.*char")
+  SET(pldes_failure_regex ".*at\ line.*char")
 
   ADD_TEST(
     NAME wlmaker_plist_test
@@ -74,5 +74,12 @@ IF(PLDES)
     COMMAND pldes "${CMAKE_CURRENT_SOURCE_DIR}/style-default.plist")
   SET_PROPERTY(
     TEST style_default_plist_test
+    PROPERTY FAIL_REGULAR_EXPRESSION "${pldes_failure_regex}")
+
+  ADD_TEST(
+    NAME root_menu_plist_test
+    COMMAND pldes "${CMAKE_CURRENT_SOURCE_DIR}/root-menu.plist")
+  SET_PROPERTY(
+    TEST root_menu_plist_test
     PROPERTY FAIL_REGULAR_EXPRESSION "${pldes_failure_regex}")
 ENDIF(PLDES)

--- a/etc/root-menu.plist
+++ b/etc/root-menu.plist
@@ -1,8 +1,8 @@
 // Definition of root menu. Follows Window Maker plist order.
 ("Root Menu",
- (Applications,
-  (Terminal, EXEC, foot),
-  (Chrome, EXEC, chrome)),
+// (Applications,
+//  (Terminal, EXEC, foot),
+//  (Chrome, EXEC, chrome)),
  ("Previous Workspace", WorkspacePrevious),
  ("Next Workspace", WorkspaceNext),
  ("Lock", LockScreen),

--- a/etc/root-menu.plist
+++ b/etc/root-menu.plist
@@ -1,8 +1,8 @@
 // Definition of root menu. Follows Window Maker plist order.
 ("Root Menu",
-// (Applications,
-//  (Terminal, EXEC, foot),
-//  (Chrome, EXEC, chrome)),
+ (Applications,
+  (Terminal, None, foot),
+  (Chrome, None, chrome)),
  ("Previous Workspace", WorkspacePrevious),
  ("Next Workspace", WorkspaceNext),
  ("Lock", LockScreen),

--- a/etc/root-menu.plist
+++ b/etc/root-menu.plist
@@ -1,0 +1,9 @@
+// Definition of root menu. Follows Window Maker plist order.
+("Root Menu",
+ (Applications,
+  (Terminal, EXEC, foot),
+  (Chrome, EXEC, chrome)),
+ ("Previous Workspace", WorkspacePrevious),
+ ("Next Workspace", WorkspaceNext),
+ ("Lock", LockScreen),
+ (Exit, Quit))

--- a/etc/root-menu.plist
+++ b/etc/root-menu.plist
@@ -1,8 +1,5 @@
 // Definition of root menu. Follows Window Maker plist order.
 ("Root Menu",
- (Applications,
-  (Terminal, None, foot),
-  (Chrome, None, chrome)),
  ("Previous Workspace", WorkspacePrevious),
  ("Next Workspace", WorkspaceNext),
  ("Lock", LockScreen),

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,7 @@ ADD_DEPENDENCIES(
   conf
   toolkit
   embedded_configuration
+  embedded_root_menu
   embedded_state
   embedded_style
   wlmaker_lib)
@@ -99,6 +100,7 @@ TARGET_LINK_LIBRARIES(
   conf
   toolkit
   embedded_configuration
+  embedded_root_menu
   embedded_state
   embedded_style
   wlmaker_protocols

--- a/src/action.c
+++ b/src/action.c
@@ -341,19 +341,13 @@ void wlmaker_action_execute(wlmaker_server_t *server_ptr,
         break;
 
     case WLMAKER_ACTION_ROOT_MENU:
-        if (NULL == server_ptr->root_menu_ptr) {
-            server_ptr->root_menu_ptr = wlmaker_root_menu_create(
-                server_ptr,
-                &server_ptr->style.window,
-                &server_ptr->style.menu,
-                false,
+        if (NULL != server_ptr->root_menu_ptr) {
+            wlmtk_menu_set_open(
+                wlmaker_root_menu_menu(server_ptr->root_menu_ptr),
+                true);
+            wlmtk_workspace_map_window(
                 wlmtk_root_get_current_workspace(server_ptr->root_ptr),
-                server_ptr->env_ptr);
-        } else {
-            window_ptr = wlmaker_root_menu_window(server_ptr->root_menu_ptr);
-            wlmtk_workspace_activate_window(
-                workspace_ptr = wlmtk_window_get_workspace(window_ptr),
-                window_ptr);
+                wlmaker_root_menu_window(server_ptr->root_menu_ptr));
         }
         break;
 

--- a/src/action.c
+++ b/src/action.c
@@ -30,6 +30,7 @@
 
 #define WLR_USE_UNSTABLE
 #include <wlr/backend/session.h>
+#include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_keyboard.h>
 #undef WLR_USE_UNSTABLE
 
@@ -341,13 +342,26 @@ void wlmaker_action_execute(wlmaker_server_t *server_ptr,
         break;
 
     case WLMAKER_ACTION_ROOT_MENU:
-        if (NULL != server_ptr->root_menu_ptr) {
-            wlmtk_menu_set_open(
-                wlmaker_root_menu_menu(server_ptr->root_menu_ptr),
-                true);
+        // TODO(kaeser@gubbe.ch): Clean up.
+        if (NULL != server_ptr->root_menu_ptr &&
+            NULL == wlmtk_window_get_workspace(
+                wlmaker_root_menu_window(server_ptr->root_menu_ptr))) {
             wlmtk_workspace_map_window(
                 wlmtk_root_get_current_workspace(server_ptr->root_ptr),
                 wlmaker_root_menu_window(server_ptr->root_menu_ptr));
+            wlmtk_window_set_position(
+                wlmaker_root_menu_window(server_ptr->root_menu_ptr),
+                server_ptr->cursor_ptr->wlr_cursor_ptr->x,
+                server_ptr->cursor_ptr->wlr_cursor_ptr->y);
+            wlmtk_workspace_confine_within(
+                wlmtk_root_get_current_workspace(server_ptr->root_ptr),
+                wlmaker_root_menu_window(server_ptr->root_menu_ptr));
+            wlmtk_menu_set_mode(
+                wlmaker_root_menu_menu(server_ptr->root_menu_ptr),
+                WLMTK_MENU_MODE_NORMAL);
+            wlmtk_menu_set_open(
+                wlmaker_root_menu_menu(server_ptr->root_menu_ptr),
+                true);
         }
         break;
 

--- a/src/action_item.c
+++ b/src/action_item.c
@@ -154,6 +154,8 @@ void _wlmaker_action_item_handle_destroy(
         listener_ptr, wlmaker_action_item_t, destroy_listener);
 
     // Clear the reference to the menu item. It is already being destroyed.
+    wlmtk_util_disconnect_listener(&action_item_ptr->destroy_listener);
+    wlmtk_util_disconnect_listener(&action_item_ptr->triggered_listener);
     action_item_ptr->menu_item_ptr = NULL;
     wlmaker_action_item_destroy(action_item_ptr);
 }

--- a/src/action_item.c
+++ b/src/action_item.c
@@ -140,7 +140,9 @@ void _wlmaker_action_item_handle_triggered(
         action_item_ptr->action);
 
     if (NULL != action_item_ptr->server_ptr->root_menu_ptr) {
-        wlmaker_root_menu_destroy(action_item_ptr->server_ptr->root_menu_ptr);
+        wlmtk_menu_set_open(
+            wlmaker_root_menu_menu(action_item_ptr->server_ptr->root_menu_ptr),
+            false);
     }
 }
 

--- a/src/conf/model.c
+++ b/src/conf/model.c
@@ -142,6 +142,7 @@ wlmcfg_string_t *wlmcfg_string_create(const char *value_ptr)
 /* ------------------------------------------------------------------------- */
 const char *wlmcfg_string_value(const wlmcfg_string_t *string_ptr)
 {
+    if (NULL == string_ptr) return NULL;  // Guard clause.
     return string_ptr->value_ptr;
 }
 

--- a/src/conf/model.c
+++ b/src/conf/model.c
@@ -111,6 +111,12 @@ void wlmcfg_object_unref(wlmcfg_object_t *object_ptr)
 }
 
 /* ------------------------------------------------------------------------- */
+wlmcfg_type_t wlmcfg_object_type(wlmcfg_object_t *object_ptr)
+{
+    return object_ptr->type;
+}
+
+/* ------------------------------------------------------------------------- */
 wlmcfg_string_t *wlmcfg_string_create(const char *value_ptr)
 {
     BS_ASSERT(NULL != value_ptr);
@@ -496,6 +502,11 @@ void test_string(bs_test_t *test_ptr)
         string_ptr,
         wlmcfg_string_from_object(object_ptr));
 
+    BS_TEST_VERIFY_EQ(
+        test_ptr,
+        WLMCFG_STRING,
+        wlmcfg_object_type(object_ptr));
+
     wlmcfg_object_unref(object_ptr);
 }
 
@@ -539,6 +550,11 @@ void test_dict(bs_test_t *test_ptr)
         wlmcfg_dict_foreach(dict_ptr, foreach_callback, &val));
     BS_TEST_VERIFY_EQ(test_ptr, 3, val);
 
+    BS_TEST_VERIFY_EQ(
+        test_ptr,
+        WLMCFG_DICT,
+        wlmcfg_object_type(wlmcfg_object_from_dict(dict_ptr)));
+
     wlmcfg_dict_unref(dict_ptr);
 }
 
@@ -564,6 +580,11 @@ void test_array(bs_test_t *test_ptr)
 
     BS_TEST_VERIFY_EQ(test_ptr, obj0_ptr, wlmcfg_array_at(array_ptr, 0));
     BS_TEST_VERIFY_EQ(test_ptr, obj1_ptr, wlmcfg_array_at(array_ptr, 1));
+
+    BS_TEST_VERIFY_EQ(
+        test_ptr,
+        WLMCFG_ARRAY,
+        wlmcfg_object_type(wlmcfg_object_from_array(array_ptr)));
 
     wlmcfg_array_unref(array_ptr);
 }

--- a/src/conf/model.h
+++ b/src/conf/model.h
@@ -64,6 +64,15 @@ wlmcfg_object_t *wlmcfg_object_ref(wlmcfg_object_t *object_ptr);
 void wlmcfg_object_unref(wlmcfg_object_t *object_ptr);
 
 /**
+ * Returns the type of `object_ptr`.
+ *
+ * @param object_ptr
+ *
+ * @return The type.
+ */
+wlmcfg_type_t wlmcfg_object_type(wlmcfg_object_t *object_ptr);
+
+/**
  * Creates a string object.
  *
  * @param value_ptr

--- a/src/root_menu.c
+++ b/src/root_menu.c
@@ -225,7 +225,8 @@ void _wlmaker_root_menu_handle_menu_open_changed(
 {
     wlmaker_root_menu_t *root_menu_ptr = BS_CONTAINER_OF(
         listener_ptr, wlmaker_root_menu_t, menu_open_changed_listener);
-    if (!wlmtk_menu_is_open(root_menu_ptr->menu_ptr)) {
+    if (!wlmtk_menu_is_open(root_menu_ptr->menu_ptr) &&
+        NULL != wlmtk_window_get_workspace(root_menu_ptr->window_ptr)) {
         wlmtk_workspace_unmap_window(
             wlmtk_window_get_workspace(root_menu_ptr->window_ptr),
             root_menu_ptr->window_ptr);

--- a/src/root_menu.c
+++ b/src/root_menu.c
@@ -35,6 +35,8 @@ struct _wlmaker_root_menu_t {
     wlmtk_content_t           content;
     /** The root menu base instance. */
     wlmtk_menu_t              *menu_ptr;
+    /** Listener for @ref wlmtk_menu_events_t::open_changed. */
+    struct wl_listener        menu_open_changed_listener;
 
     /** Back-link to the server. */
     wlmaker_server_t          *server_ptr;
@@ -42,6 +44,9 @@ struct _wlmaker_root_menu_t {
 
 static void _wlmaker_root_menu_content_request_close(
     wlmtk_content_t *content_ptr);
+static void _wlmaker_root_menu_handle_menu_open_changed(
+    struct wl_listener *listener_ptr,
+    void *data_ptr);
 static wlmaker_action_item_t *_wlmaker_root_menu_create_action_item_from_array(
     wlmcfg_array_t *array_ptr,
     const wlmtk_menu_style_t *menu_style_ptr,
@@ -66,7 +71,7 @@ wlmaker_root_menu_t *wlmaker_root_menu_create(
     const wlmtk_window_style_t *window_style_ptr,
     const wlmtk_menu_style_t *menu_style_ptr,
     bool right_click_mode,
-    wlmtk_workspace_t *workspace_ptr,
+    __UNUSED__ wlmtk_workspace_t *workspace_ptr,
     wlmtk_env_t *env_ptr)
 {
     if (wlmcfg_array_size(server_ptr->root_menu_array_ptr) <= 1) {
@@ -93,6 +98,11 @@ wlmaker_root_menu_t *wlmaker_root_menu_create(
         wlmaker_root_menu_destroy(root_menu_ptr);
         return NULL;
     }
+    wlmtk_util_connect_listener_signal(
+        &wlmtk_menu_events(root_menu_ptr->menu_ptr)->open_changed,
+        &root_menu_ptr->menu_open_changed_listener,
+        _wlmaker_root_menu_handle_menu_open_changed);
+
     if (right_click_mode) {
         wlmtk_menu_set_mode(
             wlmaker_root_menu_menu(server_ptr->root_menu_ptr),
@@ -140,13 +150,12 @@ wlmaker_root_menu_t *wlmaker_root_menu_create(
     }
     wlmtk_window_set_properties(root_menu_ptr->window_ptr, properties);
 
-    wlmtk_workspace_map_window(workspace_ptr, root_menu_ptr->window_ptr);
     if (right_click_mode) {
         wlmtk_container_pointer_grab(
-            wlmtk_window_element(root_menu_ptr->window_ptr)->parent_container_ptr,
+            wlmtk_window_element(
+                root_menu_ptr->window_ptr)->parent_container_ptr,
             wlmtk_window_element(root_menu_ptr->window_ptr));
     }
-
 
     return root_menu_ptr;
 }
@@ -175,6 +184,8 @@ void wlmaker_root_menu_destroy(wlmaker_root_menu_t *root_menu_ptr)
 
     wlmtk_content_fini(&root_menu_ptr->content);
     if (NULL != root_menu_ptr->menu_ptr) {
+        wlmtk_util_disconnect_listener(
+            &root_menu_ptr->menu_open_changed_listener);
         wlmtk_menu_destroy(root_menu_ptr->menu_ptr);
         root_menu_ptr->menu_ptr = NULL;
     }
@@ -202,7 +213,23 @@ void _wlmaker_root_menu_content_request_close(
 {
     wlmaker_root_menu_t *root_menu_ptr = BS_CONTAINER_OF(
         content_ptr, wlmaker_root_menu_t, content);
-    wlmaker_root_menu_destroy(root_menu_ptr);
+
+    wlmtk_menu_set_open(root_menu_ptr->menu_ptr, false);
+}
+
+/* ------------------------------------------------------------------------- */
+/** Handles @ref wlmtk_menu_events_t::open_changed. Unmaps window on close. */
+void _wlmaker_root_menu_handle_menu_open_changed(
+    struct wl_listener *listener_ptr,
+    __UNUSED__ void *data_ptr)
+{
+    wlmaker_root_menu_t *root_menu_ptr = BS_CONTAINER_OF(
+        listener_ptr, wlmaker_root_menu_t, menu_open_changed_listener);
+    if (!wlmtk_menu_is_open(root_menu_ptr->menu_ptr)) {
+        wlmtk_workspace_unmap_window(
+            wlmtk_window_get_workspace(root_menu_ptr->window_ptr),
+            root_menu_ptr->window_ptr);
+    }
 }
 
 /* ------------------------------------------------------------------------- */

--- a/src/root_menu.c
+++ b/src/root_menu.c
@@ -70,7 +70,6 @@ wlmaker_root_menu_t *wlmaker_root_menu_create(
     wlmaker_server_t *server_ptr,
     const wlmtk_window_style_t *window_style_ptr,
     const wlmtk_menu_style_t *menu_style_ptr,
-    bool right_click_mode,
     wlmtk_env_t *env_ptr)
 {
     if (wlmcfg_array_size(server_ptr->root_menu_array_ptr) <= 1) {
@@ -101,12 +100,6 @@ wlmaker_root_menu_t *wlmaker_root_menu_create(
         &wlmtk_menu_events(root_menu_ptr->menu_ptr)->open_changed,
         &root_menu_ptr->menu_open_changed_listener,
         _wlmaker_root_menu_handle_menu_open_changed);
-
-    if (right_click_mode) {
-        wlmtk_menu_set_mode(
-            wlmaker_root_menu_menu(server_ptr->root_menu_ptr),
-            WLMTK_MENU_MODE_RIGHTCLICK);
-    }
 
     if (!wlmtk_content_init(
             &root_menu_ptr->content,
@@ -141,20 +134,6 @@ wlmaker_root_menu_t *wlmaker_root_menu_create(
         root_menu_ptr->window_ptr,
         wlmcfg_array_string_value_at(server_ptr->root_menu_array_ptr, 0));
     wlmtk_window_set_server_side_decorated(root_menu_ptr->window_ptr, true);
-    uint32_t properties = 0;
-    if (right_click_mode) {
-        properties |= WLMTK_WINDOW_PROPERTY_RIGHTCLICK;
-    } else {
-        properties |= WLMTK_WINDOW_PROPERTY_CLOSABLE;
-    }
-    wlmtk_window_set_properties(root_menu_ptr->window_ptr, properties);
-
-    if (right_click_mode) {
-        wlmtk_container_pointer_grab(
-            wlmtk_window_element(
-                root_menu_ptr->window_ptr)->parent_container_ptr,
-            wlmtk_window_element(root_menu_ptr->window_ptr));
-    }
 
     return root_menu_ptr;
 }
@@ -229,6 +208,23 @@ void _wlmaker_root_menu_handle_menu_open_changed(
         wlmtk_workspace_unmap_window(
             wlmtk_window_get_workspace(root_menu_ptr->window_ptr),
             root_menu_ptr->window_ptr);
+    } else {
+
+        uint32_t properties = 0;
+        if (WLMTK_MENU_MODE_RIGHTCLICK ==
+            wlmtk_menu_get_mode(root_menu_ptr->menu_ptr)) {
+            properties |= WLMTK_WINDOW_PROPERTY_RIGHTCLICK;
+
+            wlmtk_container_pointer_grab(
+                wlmtk_window_element(
+                    root_menu_ptr->window_ptr)->parent_container_ptr,
+                wlmtk_window_element(root_menu_ptr->window_ptr));
+
+        } else {
+            properties |= WLMTK_WINDOW_PROPERTY_CLOSABLE;
+        }
+        wlmtk_window_set_properties(root_menu_ptr->window_ptr, properties);
+
     }
 }
 

--- a/src/root_menu.c
+++ b/src/root_menu.c
@@ -71,7 +71,6 @@ wlmaker_root_menu_t *wlmaker_root_menu_create(
     const wlmtk_window_style_t *window_style_ptr,
     const wlmtk_menu_style_t *menu_style_ptr,
     bool right_click_mode,
-    __UNUSED__ wlmtk_workspace_t *workspace_ptr,
     wlmtk_env_t *env_ptr)
 {
     if (wlmcfg_array_size(server_ptr->root_menu_array_ptr) <= 1) {

--- a/src/root_menu.c
+++ b/src/root_menu.c
@@ -258,6 +258,8 @@ wlmaker_action_item_t *_wlmaker_root_menu_create_action_item_from_array(
     wlmcfg_object_t *obj_ptr = wlmcfg_array_at(array_ptr, 1);
     if (WLMCFG_ARRAY == wlmcfg_object_type(obj_ptr)) {
 
+#if 0
+        // TODO(kaeser@gubbe.ch): Re-enable, once submenu hierarchy fixed.
         submenu_ptr = _wlmaker_root_menu_create_menu_from_array(
             array_ptr,
             menu_style_ptr,
@@ -267,6 +269,10 @@ wlmaker_action_item_t *_wlmaker_root_menu_create_action_item_from_array(
                    name_ptr);
             return NULL;
         }
+#else
+        bs_log(BS_ERROR, "Submenu definition from plist yet unsupported.");
+        return NULL;
+#endif
 
     } else {
         const char *action_name_ptr = wlmcfg_string_value(

--- a/src/root_menu.c
+++ b/src/root_menu.c
@@ -78,6 +78,16 @@ wlmaker_root_menu_t *wlmaker_root_menu_create(
     wlmtk_workspace_t *workspace_ptr,
     wlmtk_env_t *env_ptr)
 {
+    if (wlmcfg_array_size(server_ptr->root_menu_array_ptr) <= 1) {
+        bs_log(BS_ERROR, "Needs > 1 array element for menu definition.");
+        return NULL;
+    }
+    if (WLMCFG_STRING != wlmcfg_object_type(
+            wlmcfg_array_at(server_ptr->root_menu_array_ptr, 0))) {
+        bs_log(BS_ERROR, "Array element [0] must be a string.");
+        return NULL;
+    }
+
     wlmaker_root_menu_t *root_menu_ptr = logged_calloc(
         1, sizeof(wlmaker_root_menu_t));
     if (NULL == root_menu_ptr) return NULL;
@@ -94,8 +104,6 @@ wlmaker_root_menu_t *wlmaker_root_menu_create(
             wlmaker_root_menu_menu(server_ptr->root_menu_ptr),
             WLMTK_MENU_MODE_RIGHTCLICK);
     }
-
-    // FIXME
 
     for (const wlmaker_root_menu_item_t *i_ptr = &_wlmaker_root_menu_items[0];
          i_ptr->text_ptr != NULL;
@@ -144,7 +152,9 @@ wlmaker_root_menu_t *wlmaker_root_menu_create(
         wlmaker_root_menu_destroy(root_menu_ptr);
         return NULL;
     }
-    wlmtk_window_set_title(root_menu_ptr->window_ptr, "Root Menu");
+    wlmtk_window_set_title(
+        root_menu_ptr->window_ptr,
+        wlmcfg_array_string_value_at(server_ptr->root_menu_array_ptr, 0));
     wlmtk_window_set_server_side_decorated(root_menu_ptr->window_ptr, true);
     uint32_t properties = 0;
     if (right_click_mode) {

--- a/src/root_menu.c
+++ b/src/root_menu.c
@@ -95,6 +95,8 @@ wlmaker_root_menu_t *wlmaker_root_menu_create(
             WLMTK_MENU_MODE_RIGHTCLICK);
     }
 
+    // FIXME
+
     for (const wlmaker_root_menu_item_t *i_ptr = &_wlmaker_root_menu_items[0];
          i_ptr->text_ptr != NULL;
          ++i_ptr) {

--- a/src/root_menu.h
+++ b/src/root_menu.h
@@ -38,7 +38,6 @@ extern "C" {
  * @param window_style_ptr
  * @param menu_style_ptr
  * @param env_ptr
- * @param workspace_ptr
  * @param right_click_mode
  *
  * @return Handle of the root menu, or NULL on error.
@@ -48,7 +47,6 @@ wlmaker_root_menu_t *wlmaker_root_menu_create(
     const wlmtk_window_style_t *window_style_ptr,
     const wlmtk_menu_style_t *menu_style_ptr,
     bool right_click_mode,
-    wlmtk_workspace_t *workspace_ptr,
     wlmtk_env_t *env_ptr);
 
 /**

--- a/src/root_menu.h
+++ b/src/root_menu.h
@@ -38,7 +38,6 @@ extern "C" {
  * @param window_style_ptr
  * @param menu_style_ptr
  * @param env_ptr
- * @param right_click_mode
  *
  * @return Handle of the root menu, or NULL on error.
  */
@@ -46,7 +45,6 @@ wlmaker_root_menu_t *wlmaker_root_menu_create(
     wlmaker_server_t *server_ptr,
     const wlmtk_window_style_t *window_style_ptr,
     const wlmtk_menu_style_t *menu_style_ptr,
-    bool right_click_mode,
     wlmtk_env_t *env_ptr);
 
 /**

--- a/src/server.c
+++ b/src/server.c
@@ -793,24 +793,23 @@ void _wlmaker_server_unclaimed_button_event_handler(
 
     if (BTN_RIGHT == button_event_ptr->button &&
         WLMTK_BUTTON_DOWN == button_event_ptr->type &&
-        NULL == server_ptr->root_menu_ptr) {
-        server_ptr->root_menu_ptr = wlmaker_root_menu_create(
-            server_ptr,
-            &server_ptr->style.window,
-            &server_ptr->style.menu,
-            true,
+        NULL != server_ptr->root_menu_ptr) {
+        wlmtk_menu_set_open(
+            wlmaker_root_menu_menu(server_ptr->root_menu_ptr),
+            true);
+        wlmtk_workspace_map_window(
             wlmtk_root_get_current_workspace(server_ptr->root_ptr),
-            server_ptr->env_ptr);
-        if (NULL != server_ptr->root_menu_ptr) {
-            wlmtk_window_set_position(
-                wlmaker_root_menu_window(server_ptr->root_menu_ptr),
-                server_ptr->cursor_ptr->wlr_cursor_ptr->x,
-                server_ptr->cursor_ptr->wlr_cursor_ptr->y);
-
-            wlmtk_workspace_confine_within(
-                wlmtk_root_get_current_workspace(server_ptr->root_ptr),
-                wlmaker_root_menu_window(server_ptr->root_menu_ptr));
-        }
+            wlmaker_root_menu_window(server_ptr->root_menu_ptr));
+        wlmtk_window_set_position(
+            wlmaker_root_menu_window(server_ptr->root_menu_ptr),
+            server_ptr->cursor_ptr->wlr_cursor_ptr->x,
+            server_ptr->cursor_ptr->wlr_cursor_ptr->y);
+        wlmtk_workspace_confine_within(
+            wlmtk_root_get_current_workspace(server_ptr->root_ptr),
+            wlmaker_root_menu_window(server_ptr->root_menu_ptr));
+        wlmtk_menu_set_mode(
+            wlmaker_root_menu_menu(server_ptr->root_menu_ptr),
+            WLMTK_MENU_MODE_RIGHTCLICK);
     }
 }
 

--- a/src/server.c
+++ b/src/server.c
@@ -793,7 +793,9 @@ void _wlmaker_server_unclaimed_button_event_handler(
 
     if (BTN_RIGHT == button_event_ptr->button &&
         WLMTK_BUTTON_DOWN == button_event_ptr->type &&
-        NULL != server_ptr->root_menu_ptr) {
+        NULL != server_ptr->root_menu_ptr &&
+        !wlmtk_menu_is_open(
+            wlmaker_root_menu_menu(server_ptr->root_menu_ptr))) {
         wlmtk_menu_set_open(
             wlmaker_root_menu_menu(server_ptr->root_menu_ptr),
             true);

--- a/src/server.c
+++ b/src/server.c
@@ -794,11 +794,9 @@ void _wlmaker_server_unclaimed_button_event_handler(
     if (BTN_RIGHT == button_event_ptr->button &&
         WLMTK_BUTTON_DOWN == button_event_ptr->type &&
         NULL != server_ptr->root_menu_ptr &&
+        // TODO(kaeser@gubbe.ch): Clean up.
         !wlmtk_menu_is_open(
             wlmaker_root_menu_menu(server_ptr->root_menu_ptr))) {
-        wlmtk_menu_set_open(
-            wlmaker_root_menu_menu(server_ptr->root_menu_ptr),
-            true);
         wlmtk_workspace_map_window(
             wlmtk_root_get_current_workspace(server_ptr->root_ptr),
             wlmaker_root_menu_window(server_ptr->root_menu_ptr));
@@ -812,6 +810,9 @@ void _wlmaker_server_unclaimed_button_event_handler(
         wlmtk_menu_set_mode(
             wlmaker_root_menu_menu(server_ptr->root_menu_ptr),
             WLMTK_MENU_MODE_RIGHTCLICK);
+        wlmtk_menu_set_open(
+            wlmaker_root_menu_menu(server_ptr->root_menu_ptr),
+            true);
     }
 }
 

--- a/src/server.h
+++ b/src/server.h
@@ -200,6 +200,8 @@ struct _wlmaker_server_t {
 
     /** Root menu, when active. NULL when not invoked. */
     wlmaker_root_menu_t       *root_menu_ptr;
+    /** Parsed contents of the root menu definition, from plist. */
+    wlmcfg_array_t            *root_menu_array_ptr;
     /** Listener for `unclaimed_button_event` signal raised by `wlmtk_root`. */
     struct wl_listener        unclaimed_button_event_listener;
 

--- a/src/wlmaker.c
+++ b/src/wlmaker.c
@@ -370,7 +370,6 @@ int main(__UNUSED__ int argc, __UNUSED__ const char **argv)
         server_ptr,
         &server_ptr->style.window,
         &server_ptr->style.menu,
-        false,
         server_ptr->env_ptr);
     if (NULL == server_ptr->root_menu_ptr) {
         return EXIT_FAILURE;

--- a/src/wlmaker.c
+++ b/src/wlmaker.c
@@ -41,6 +41,7 @@
 #include "task_list.h"
 
 #include "style_default.h"
+#include "../etc/root_menu.h"
 
 /** Will hold the value of --config_file. */
 static char *wlmaker_arg_config_file_ptr = NULL;
@@ -48,6 +49,8 @@ static char *wlmaker_arg_config_file_ptr = NULL;
 static char *wlmaker_arg_state_file_ptr = NULL;
 /** Will hold the value of --style_file. */
 static char *wlmaker_arg_style_file_ptr = NULL;
+/** Will hold the value of --root_menu_file. */
+static char *wlmaker_arg_root_menu_file_ptr = NULL;
 
 /** Startup options for the server. */
 static wlmaker_server_options_t wlmaker_server_options = {
@@ -94,6 +97,12 @@ static const bs_arg_t wlmaker_args[] = {
         "will use a built-in default style.",
         NULL,
         &wlmaker_arg_style_file_ptr),
+    BS_ARG_STRING(
+        "root_menu_file",
+        "Optional: Path to a file describing the root menu. If not provided, "
+        "wlmaker will use a built-in definition for the root menu.",
+        NULL,
+        &wlmaker_arg_root_menu_file_ptr),
     BS_ARG_ENUM(
         "log_level",
         "Log level to apply. One of DEBUG, INFO, WARNING, ERROR.",
@@ -345,6 +354,18 @@ int main(__UNUSED__ int argc, __UNUSED__ const char **argv)
                   &server_ptr->style));
     wlmcfg_dict_unref(style_dict_ptr);
 
+    if (NULL != wlmaker_arg_root_menu_file_ptr) {
+        server_ptr->root_menu_array_ptr = wlmcfg_array_from_object(
+            wlmcfg_create_object_from_plist_file(
+                wlmaker_arg_root_menu_file_ptr));
+    } else {
+        server_ptr->root_menu_array_ptr = wlmcfg_array_from_object(
+            wlmcfg_create_object_from_plist_data(
+                embedded_binary_root_menu_data,
+                embedded_binary_root_menu_size));
+    }
+    if (NULL == server_ptr->root_menu_array_ptr) return EXIT_FAILURE;
+
     wlmaker_action_handle_t *action_handle_ptr = wlmaker_action_bind_keys(
         server_ptr,
         wlmcfg_dict_get_dict(config_dict_ptr, wlmaker_action_config_dict_key));
@@ -401,6 +422,7 @@ int main(__UNUSED__ int argc, __UNUSED__ const char **argv)
     if (NULL != clip_ptr) wlmaker_clip_destroy(clip_ptr);
     if (NULL != dock_ptr) wlmaker_dock_destroy(dock_ptr);
     wlmaker_action_unbind_keys(action_handle_ptr);
+    wlmcfg_array_unref(server_ptr->root_menu_array_ptr);
     wlmaker_server_destroy(server_ptr);
 
     bs_subprocess_t *sp_ptr;

--- a/src/wlmaker.c
+++ b/src/wlmaker.c
@@ -365,6 +365,17 @@ int main(__UNUSED__ int argc, __UNUSED__ const char **argv)
                 embedded_binary_root_menu_size));
     }
     if (NULL == server_ptr->root_menu_array_ptr) return EXIT_FAILURE;
+    // TODO(kaeser@gubbe.ch): Uh, that's ugly...
+    server_ptr->root_menu_ptr = wlmaker_root_menu_create(
+        server_ptr,
+        &server_ptr->style.window,
+        &server_ptr->style.menu,
+        false,
+        NULL,
+        server_ptr->env_ptr);
+    if (NULL == server_ptr->root_menu_ptr) {
+        return EXIT_FAILURE;
+    }
 
     wlmaker_action_handle_t *action_handle_ptr = wlmaker_action_bind_keys(
         server_ptr,

--- a/src/wlmaker.c
+++ b/src/wlmaker.c
@@ -376,6 +376,9 @@ int main(__UNUSED__ int argc, __UNUSED__ const char **argv)
     if (NULL == server_ptr->root_menu_ptr) {
         return EXIT_FAILURE;
     }
+    wlmtk_menu_set_open(
+        wlmaker_root_menu_menu(server_ptr->root_menu_ptr),
+        false);
 
     wlmaker_action_handle_t *action_handle_ptr = wlmaker_action_bind_keys(
         server_ptr,

--- a/src/wlmaker.c
+++ b/src/wlmaker.c
@@ -371,7 +371,6 @@ int main(__UNUSED__ int argc, __UNUSED__ const char **argv)
         &server_ptr->style.window,
         &server_ptr->style.menu,
         false,
-        NULL,
         server_ptr->env_ptr);
     if (NULL == server_ptr->root_menu_ptr) {
         return EXIT_FAILURE;


### PR DESCRIPTION
Initial implementation, part of what is needed for #87 and #90:
* Loads a plist as specified from a command-line argument.
* Parses the file and builds a flat menu accordingly.

Missing:
* Support for submenus.
* Actions for launching programs (Window Maker's ´EXEC´ and ´SHEXEC´ directives).
* Loading the file from default locations (´${HOME}´ and system default).