### PR TITLE
Makes 0.18 the minimum wlroots required version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,13 +57,8 @@ PKG_CHECK_MODULES(XKBCOMMON REQUIRED IMPORTED_TARGET xkbcommon>=1.5.0)
 # XWayland considered optional.
 PKG_CHECK_MODULES(XWAYLAND xwayland>=22.1.9)
 
-# We aim to support wlroots 0.17 and 0.18. With wlroots 0.18, the package name
-# includes the major/minor version, so we need this extra check.
+# We build for wlroots 0.18.
 PKG_CHECK_MODULES(WLROOTS IMPORTED_TARGET wlroots-0.18>=0.18)
-IF(NOT WLROOTS_FOUND)
-  # If that wasn't found, we'll resort to the (recent) 0.17.4 version.
-  PKG_CHECK_MODULES(WLROOTS REQUIRED IMPORTED_TARGET wlroots>=0.17.3)
-ENDIF(NOT WLROOTS_FOUND)
 
 # Configuration. Remove CMakeCache.txt to rerun...
 OPTION(config_DEBUG "Include debugging information" ON)


### PR DESCRIPTION
The API for output manager has diverged a bit, and the CI tests do no longer catch 0.17 deviations. Major distros are at 0.18 already.