### PR TITLE
Adds WAYLAND_INCLUDE_DIRS to backend library, and publicly add libbase and wayland[-client].

### DIFF
--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -31,6 +31,7 @@ TARGET_INCLUDE_DIRECTORIES(
   PUBLIC
   ${PROJECT_SOURCE_DIR}/include
   PRIVATE
+  ${WAYLAND_INCLUDE_DIRS}
   ${WLROOTS_INCLUDE_DIRS}
   ${PROJECT_SOURCE_DIR}/include
 )
@@ -55,9 +56,10 @@ TARGET_COMPILE_OPTIONS(
 TARGET_LINK_LIBRARIES(
   backend
   PUBLIC
-  libbase_plist
-  PRIVATE
   libbase
+  libbase_plist
+  PkgConfig::WAYLAND
+  PRIVATE
   toolkit
   PkgConfig::WLROOTS)
 


### PR DESCRIPTION
The error from #242 indicates that the src/backend library odes not properly expose the Wayland dependency. That change *might* fix the issue; but I'll need to pull OpenSUSE Tumbleweed to verify.

In any case, linking `libbase`, `libbase_plist` and `PkgConfig::WAYLAND` as `PUBLIC` seems correct.