### PR TITLE
roadmap: Refines the feature list, and updates roadmap + toplevel README for it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,37 +19,41 @@ How it looks, running in a window using the default theme:
 
 **Early access**: Wayland Maker covers elementary compositor functionality on single-monitor output. Please report what's missing or broken!
 
+See [here](doc/FEATURES.md) for a detailed list of implemented or planned
+features, or the [roadmap](doc/ROADMAP.md) for what's planned for the upcoming
+versions.
+
 Highlights for current version ([0.5](https://github.com/phkaeser/wlmaker/releases/tag/v0.5)):
 
 * *new:* Window menu and [configurable](https://github.com/phkaeser/wlmaker/blob/main/etc/root-menu.plist) root menu.
-* *new:* Fixes to `wlr_layer_shell_unstable_v1` implementation, early support for keyboard interactivity.
+* *new:* Fixes to `wlr-layer-shell-unstable-v1` implementation, early support for keyboard interactivity.
 * Builds with [wlroots 0.18](https://gitlab.freedesktop.org/wlroots/wlroots/-/tags).
 * Configurable layout and scaling for the output.
 * Hot corners with configurable actions, default to 'lock' or 'inhibit' locking.
-* Screen saver support, through `ext_session_lock_v1` and `idle_inhibit_unstable_v1` protocols.
+* Screen saver support, through `ext-session-lock-v1` and `idle-inhibit-unstable-v1` protocols.
 * Configurable through plist text files: [base configuration](etc/wlmaker.plist),
   [style](etc/style.plist), [root menu](etc/root-menu.plist) and
   [docks & workspaces](etc/wlmaker-state.plist).
-* wlr layer shell support (`wlr_layer_shell_unstable_v1`), fully implemented & tested.
+* wlr layer shell support (`wlr-layer-shell-unstable-v1`), fully implemented & tested.
 * Appearance matches Window Maker: Decorations, dock, clip.
 * Support for Wayland XDG shell (mostly complete. Bug reports welcome).
 * Initial support for X11 applications (positioning and specific modes are missing).
   Use `--start_xwayland` argument to enable XWayland, it's off by default.
 * A prototype DockApp (`apps/wlmclock`).
 
-For further details, see the [roadmap](doc/ROADMAP.md).
+### Wayland protocols
 
-Protocol support:
-
+* `ext-session-lock-v1`: Implemented & tested.
+* `idle-inhibit-unstable-v1`: Implemented, untested.
+* `wlr-layer-shell-unstable-v1`: Largely implemented & tested.
+* `wlr-output-management-unstable-v1`: Implemented & tested, for v0.6.
+* `wlr-screencopy-unstable-v1` : Implemented & tested, for v0.6.
 * `xdg-decoration-unstable-v1`: Implemented & tested.
-* `ext_session_lock_v1`: Implemented & tested.
-* `wlr_layer_shell_unstable_v1`: Largely implemented & tested.
-* `xdg_shell`: Largely implemented & tested.
-* `idle_inhibit_unstable_v1`: Implemented, untested.
+* `xdg-shell`: Largely implemented & tested.
 
 ### Build & use it!
 
-* From source: Please follow the [detailled build instructions](doc/BUILD.md)
+* From source: Please follow the [detailed build instructions](doc/BUILD.md)
   for a step-by-step guide.
 
 * Once compiled, see the [these instructions](doc/RUN.md) on how to run

--- a/doc/FEATURES.md
+++ b/doc/FEATURES.md
@@ -4,7 +4,7 @@ This document lists features implemented, planned or proposed for wlmaker,
 and sets them in reference to documented [Window Maker](https://www.windowmaker.org/)
 features, where available.
 
-Features should be in the following state(s):
+Features should be in any of the following state(s):
 
 * [ ] -- **Listed**: A desired feature for the future.
 * [ ] :clock3: -- **Planned**: Listed on the roadmap for an upcoming version.
@@ -90,7 +90,10 @@ TBD: Raise/Lower.
 
 ### Moving a Window
 
-TBD.
+* [x] :white_check_mark: Left-dragging the title bar moves the window.
+* [x] :white_check_mark: Holding Alt and left-dragging while anywhere on the window
+  moves the window.
+* [ ] The modifier key for left-dragging anywhere on the content is configurable.
 
 ### Shading a Window
 
@@ -101,7 +104,10 @@ TBD.
 
 ### Miniaturizing a Window
 
-TBD.
+* [ ] Left-click on the miniaturize button collapses the window into a mini-window.
+* [ ] The transition to a mini-window (and back) is animated.
+* [ ] The mini-window is shown in the *Icon Area* and is distinguishable
+  from an application icon.
 
 ### Closing a Window
 
@@ -122,4 +128,197 @@ TBD.
 
 ### Window Placement
 
+* [ ] New windows are placed on a suitable free spot, if available.
+* [ ] Once screen is full, windows are stacked with a moderate displacement between each.
+* [ ] "Gravity" to snap and stick to borders.
+* [ ] Pulling a window towards an edge of an output sets window to occupy that edge.
+
+### Window attributes
+
+* [ ] Permit to configure attributes by application ID and/or window title.
+* [ ] Permit to disable titlebar, resizebar, close button, miniaturize button.
+* [ ] Option to keep on top.
+* [ ] Option to be "omnipresent", ie. shown across all workspaces.
+* [ ] To determine: Start miniaturized.
+* [ ] To determine: Skip window list.
+* [ ] Specify an icon, where not provided.
+* [ ] Specify initial workspace.
+* [ ] Scaling factor (fractional scale).
+* [ ] Use *XDG Shell* `wm_capabilities` to advertise capabilities, as attributes permit.
+
+## Workspaces
+
+* [x] :white_check_mark: Workspaces for startup are configurable in the *state*
+  configuration file.
+* [x] :white_check_mark: Navigate between workspaces using a configurable key
+  combination (ctrl-arrow).
+* [ ] Navigate between workspaces through scrollwheel or buttons on the *Clip*.
+* [ ] When saving state, the current workspace configuation is saved to the *state*
+  configuration file.
+
+## Workspaces menu
+
+* [ ] "New", to create a new workspace.
+* [ ] "Destroy" or "Destroy last" for destroying a workspace.
+* [ ] Menu item to navigate to the provided workspace.
+* [ ] Ctrl-click on menu item to rename the workspace, through a dialog.
+
+## Navigating workspaces
+
+* [ ] Optional display the workspace name after moving to a new workspace.
+* [ ] The transition between workspaces is animated.
+
+## Window assignments
+
+* [ ] Send window to another workspace through ctrl-shift-arrow (or configurable combination)
+* [ ] Navigate to workspace using key combination (eg. Alt-<number>)
+* [ ] Navigate to same workspace in next group, using key combination.
+* [ ] Support workspace groups, addressable by an extra modifier of key combinations.
+
+## Menu contents
+
+### Root menu
+
+* [*] :white_check_mark: Menu configurable as a plist.
+* [ ] Generated from XDG repository ([#90](https://github.com/phkaeser/wlmaker/issues/90)).
+
+### Window commands
+
+* [*] :white_check_mark: Static contents, shown when right-clicking on title bar.
+* [ ] Items and contents adapting to state (eg. no "maximize" when maximized).
+
+## Wayland protocol support
+
+### `ext-idle-notify-v1`
+
+* [ ] Implement.
+
+### `ext-session-lock-v1`
+
+* [x] :white_check_mark: Implement, verified on single output.
+* [ ] Make it work on multiple outputs: Lock surface shown on each.
+
+### `idle-inhibit-unstable-v1`
+
+* [x] :white_check_mark: Implement.
+* [ ] Test it. Didn't have a tool when adding it.
+
+### `wlr-foreign-toplevel-management-unstable-v1`
+
+* [ ] Implement.
+
+### `wlr-layer-shell-unstable-v1`
+
+* [x] :white_check_mark: Support layer panels.
+* [ ] Support `keyboard_interactivity` for upper layers.
+
+### `wlr-output-management-unstable-v1`
+
+* [x] :white_check_mark: Implemented, and verified with `wlr-randr` and `wldisplays`.
+* [x] :white_check_mark: Scale, transformation and mode of output is configurable
+  in *config* file, by matching output attributes.
+
+### ``wlr-screencopy-unstable-v1`
+
+* [x] :white_check_mark: Implemented, works for `wdisplays`.
+
+### `xdg-activation-v1`
+
+* [ ] Implement.
+
+### `xdg-decoration`
+
+* [x] Implemented.
+
+### `xdg-shell`
+
+* [x] :white_check_mark: Support toplevel shell and popups.
+* [ ] Refactor: split `xdg_surface` off `xdg_toplevel`, encode as separate classes.
+* [ ] Accept state (maximize, fullscreen, ...) before mapping the surface, but apply
+  them only after first commit.
+* [ ] Accept decoration requests before first commit, and forward them after the first
+  commit was received (see also https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4648#note_2386593).
+* [ ] Support `set_parent`, associating a child `wlmtk_window_t` with a paraent.
+* [ ] Consider suggested position on `show_window_menu`
+
+## X11 client support (XWayland)
+
+* [x] :white_check_mark: Support windows and popups, enough for `xterm` and `emacs`.
+* [ ] Modal windows should be a child `wlmtk_window_t`
+* [ ] Investigate if the connection can identify the real X client, not the
+  XWayland connection.
+
+## Dock, Clip, Icon Area
+
+* [x] :white_check_mark: Launcher item display when the app is "launching", and "running".
+* [ ] Drag-and-drop icons between icon area, dock app and clip.
+* [ ] Investigate if & how to use icons specified in XDG desktop entry.
+* [ ] Aspirational: Aim to have *Dock* and *Clip* running as separate process(es).
+* [ ] Entries in Dock/Clip have a settings menu to define path & icon.
+
+### Dock
+
+* [x] :white_check_mark: The entries in the dock are loaded from the *state* file.
+* [x] :white_check_mark: Edge and anchor are configured in *state* config file.
+* [x] :white_check_mark: Entries have configurable icon image, for when app isn't running.
+* [ ] Entries can be configured to autostart upon wlmaker startup.
+* [ ] Entries can be configured to be "locked", preventing accidental removal.
+* [ ] Entries can have a drawer, to nest a second layer of entries.
+* [ ] When saving state, dock entries are saved into *state* config file.
+
+### Clip
+
+* [x] :white_check_mark: edge and anchor are configured in *state* config file.
+* [ ] Entries can be configured to be "omnipresent", but are per-workspace by default.
+* [ ] When saving state, clip entries are saved into *state* config file.
+
+### Icon Area
+
+* [ ] Display running apps using the configured icon.
+* [ ] Consider showing a miniature of the toplevel surface in the icon.
 TBD.
+
+### Dock Apps
+
+* [x] :white_check_mark: Have a demo app using the icon protocol (`wlmclock`)
+* [ ] Configurable to show in Dock or Clip.
+* [ ] When starting from anywhere, dock apps show in icon area.
+* [ ] When starting from a docked or clipped position, show there.
+* [ ] Add another demo DockApp (julia set).
+
+## Toolkit
+
+* [ ] Use pango proper over cairo toy interface. Use relative sizes to scale.
+* [ ] Support configurable fractional scale for all decoration elements.
+* [ ] Text strings are looked up from a table, for internationalization.
+
+### Menu
+
+* [ ] Permit navigation by keys
+* [ ] Position all menus to remain within output.
+* [ ] Re-position to remain within output when submenu opens.
+* [ ] Handle case of too manu menu items that exceed output space.
+
+## Devices
+
+### Multiple outputs ([#122](https://github.com/phkaeser/wlmaker/issues/122))
+
+* [x] :white_check_mark: Output layout configurable via third-party tool, eg. `wlr-randr`.
+* [ ] When saving state, store the current layout in the *state* config file.
+
+
+## General
+
+* [ ] Use SVG as principal format for icons.
+* [ ] Add a logo.
+* [ ] Add an info panel, showing version, name, copyright and link to documentation.
+* [ ] Upon first launch, show an onboarding screen with basic instructions
+  ([#131](https://github.com/phkaeser/wlmaker/issues/131)).
+
+### CI/CD
+
+* [x] :white_check_mark Have github workflows to build with GCC and Clang, x86_64
+  and arm64, and Linux + *BSD.
+* [ ] Generate the screenshots (extend wlroots for a PNG backend?)
+* [ ] Provide a binary package of wlmaker, from HEAD.
+* [ ] Run static checks and enforce them on pull requests (eg. https://www.kitware.com/static-checks-with-cmake-cdash-iwyu-clang-tidy-lwyu-cpplint-and-cppcheck/).

--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -51,9 +51,8 @@ See the [Detailed Feature List](FEATURES.md) for details.
   * Add "output configuration" item to the root menu. (eg. XF86Display key?)
 
 * Menu
-  * Keyboard navigation.
+  * Permit navigation by keys
   * Generate from XDG repository ([#90](https://github.com/phkaeser/wlmaker/issues/90)).
-  * Re-position to remain within output when adding submenus.
 
 * Bug fixes
   * Resize-from-left jitter observed on the raspi or with gnome-terminal.
@@ -325,60 +324,11 @@ See the [Detailed Feature List](FEATURES.md) for details.
 
 ## Window Maker features
 
-* "sloppy focus": Focus that follows mouse, and activates windows after a configurable delay (eg. 200ms). Also to auto-raise activated windows.
-* "workspace groups": Up to 10 workspaces are directly indexable. A further layer of key combos moves to workspace N+10/N-10.
-
 ## Overall
 
-* wlroots handling
-  * Split xdg_surface off xdg_toplevel.
-  * Accept state changes (maximize, fullscreen, ...) also before being mapped.
-    Apply when mapping.
-  * Accept decoration requests before first commit. And forward them after
-    the first commit (see also https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4648#note_2386593).
-
-* Full support for multiple outputs ([#122](https://github.com/phkaeser/wlmaker/issues/122))
-  * Permit layout configuration via third-party tool (eg. wlr-randr).
-  * Test & scope the changes required.
-
-* Wayland protocol adherence.
-  * Support XDG `wm_capabilities` and advertise the compositor features.
-  * Fullscreen: Hide all other visuals when a window takes fullscreen.
-  * `xdg-shell`: set_parent, by child wlmtk_window_t.
-  * `xdg-shell`: consider suggested position on `show_window_menu`.
-  * Test `idle-inhibit-unstable-v1`. Didn't have a tool when adding.xs
-  * Add `ext-idle-notify-v1` support.
-  * Add `xdg-activation-v1` support.
-  * Add `wlr-foreign-toplevel-management-unstable-v1` support.
-  * Support `keyboard_interactivity` for `wlr-layer-shell-unstable-v1`.
-
-* XWayland support (X11 clients).
-  * Proper handling of modal windows: Should be a child wlmtk_window_t to itself.
-  * Permit identifying the real X client, not the XWayland connection.
-  * Have a test matrix build that verifies the build works without XWayland.
-  * Fix bug with emacs hanging on saving clipboard (observed once).
-
-* Dock Apps.
-  * Attached to dock (visible across workspaces) or clip (per workspace).
-  * Configurable to show permanently also in clip.
-  * Drag-and-drop between clip and dock.
-  * Ideally: With a Wayland protocol that permits running the dock and clip as
-    separate binary, independent of the compositor.
-  * Second Demo DockApp (julia set).
-
-* Visualization / icons for running apps.
-  * Re-build this unsing wlmtk.
-  * Show in 'iconified' area.
-  * Drag-and-drop into clip or dock area.
-  * Consider running this as task selector, as separate binary.
-
 * Window attributes
-  * Determine how to detect client preferences.
-  * Configurable and overridable (titlebar, resizebar, buttons, ...).
-  * Scaling factor per application.
   * Build and test a clear model for `organic`/`maximized`/`fullscreen` state
     switches and precedence.
-  * Window menu, adapting to state (eg. no "maximize" when maximized).
 
 * Application support.
   * Icons retrieved and used for iconified windows. See [themes](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html).
@@ -386,28 +336,11 @@ See the [Detailed Feature List](FEATURES.md) for details.
 
 * XDG Complianace
   * Review and define what to support from https://specifications.freedesktop.org.
-  * Autostart.
   * System Tray (potentially through a Dock App)
   * Icon Themes
   * Notifications (potentially through a Dock App)
 
-* Application launcher
-  * Show icon from XDG desktop entry.
-  * For running apps, consider showing the surface on the tile.
-  * Configuration menu: Commandline, and further settings.
-  * Use SVG as principal icon format, and scale without quality loss.
-
-* A logo and info panel.
-
-* Window actions
-  * Send to another workspace, using menu or key combinations.
-  * Window *shade* triggered by double-click, and animated.
-  * Minimize (*iconify*) windows, using wlmtk.
-  * Window menu.
-  * Application ID (from XDG shell and/or X11).
-
 * Configuration file and parser:
-  * Permit dock, clip and output state to save state to configuration files.
   * Support different background styles (fill, image).
   * Make semicolon-after-value required, for consistency with GNUstep.
   * Theme.
@@ -419,21 +352,11 @@ See the [Detailed Feature List](FEATURES.md) for details.
   * Verify support of multi-layout configurations (eg. `shift_caps_toggle`)
   * Support ChromeOS layout switch hotkey (`Ctrl+Shift+Space`)
 
-* Window placement
-  * Automatic placement on a free spot.
-  * Gravity to snap to and stick to borders.
-  * Mouse pull to sides or corners will set window to half or quarter screen.
-
 * Configuration tool, similar to WPrefs.
 
 * Compositor features
   * Bindable hotkeys.
   * Pointer position, to support apps like wmscreen or xeyes.
-  * Evaluate "snap layout" mechanism, for pre-arranged Window placement.
-
-* Internationalization and solid font support
-  * Move from cairo toy interface to using pango proper.
-  * All text strings to be configurable and swappable.
 
 * Commandline flags to support:
   * icon lookup paths beyond the hardcoded defaults.
@@ -444,13 +367,6 @@ See the [Detailed Feature List](FEATURES.md) for details.
 
 * Exploratory ideas
   * Stretch: Consider supporting XScreenSaver (or visualization modules).
-
-* Toolkit improvements
-  * Menu
-    * Permit navigation by keys
-    * Position all menus to remain within output.
-    * Re-position to remain within output when submenu opens.
-    * Handle case of too manu menu items that exceed output space.
 
 ## Visualization and effects
 
@@ -475,13 +391,6 @@ See the [Detailed Feature List](FEATURES.md) for details.
 * Network monitor.
 * Laptop battery status.
 * Julia set.
-
-## Build, compile, deployment
-
-* Run static checks and enforce them on pull requests (eg. https://www.kitware.com/static-checks-with-cmake-cdash-iwyu-clang-tidy-lwyu-cpplint-and-cppcheck/).
-* Provide binary package of wlmaker.
-* Run github workflows to build with GCC and Clang, x86_64 and arm64, and Linux + *BSD.
-* Look into whether the screenshots can be scripted.
 
 ## Non-Goals
 


### PR DESCRIPTION
A further step towards splitting the doc, as found in #243.