### PR TITLE
install: Fixes wrong Exec path in wlmaker.desktop.

### DIFF
--- a/share/wlmaker.desktop.in
+++ b/share/wlmaker.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Name=WaylandMaker
 Comment=A Wayland compositor inspired by Window Maker
-Exec=@CMAKE_INSTALL_PREFIX@/bin/wlmaker.sh
+Exec=@CMAKE_INSTALL_PREFIX@/bin/wlmaker
 Type=Application


### PR DESCRIPTION
Fixes #260 . That was a never-fixed left-over from when there was still a wrapper script.