### PR TITLE
build: Temporarily disable build for openSUSE Tumbleweed, as it's broken.

### DIFF
--- a/.github/workflows/build-for-opensuse-tumbleweed.yml
+++ b/.github/workflows/build-for-opensuse-tumbleweed.yml
@@ -2,9 +2,9 @@ name: Build for openSUSE Tumbleweed
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "disabled-main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "disabled-main" ]
 
 jobs:
   test:


### PR DESCRIPTION
See #267 