### PR TITLE
build: Re-enable workflow for openSUSE Tumbleweed, following reports that the dependencies permit building now.

### DIFF
--- a/.github/workflows/build-for-opensuse-tumbleweed.yml
+++ b/.github/workflows/build-for-opensuse-tumbleweed.yml
@@ -2,9 +2,9 @@ name: Build for openSUSE Tumbleweed
 
 on:
   push:
-    branches: [ "disabled-main" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "disabled-main" ]
+    branches: [ "main" ]
 
 jobs:
   test:


### PR DESCRIPTION
Fixes #267 