### PR TITLE
xdg_toplevel: Fixes handling of clients not setting geometry (eg. wlroots compositors), using wlr_surface_get_extents() as fallback.

### DIFF
--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -51,7 +51,7 @@ See the [Detailed Feature List](FEATURES.md) for details.
 
 * Bug fixes
   * [done] Fix crash when changing to different terminal ([#438](https://github.com/phkaeser/wlmaker/issues/438)).
-  * Fix wlmaker not showing window of wlroots clients  ([#439](https://github.com/phkaeser/wlmaker/issues/439)).
+  * [done]  wlmaker not showing window of wlroots clients  ([#439](https://github.com/phkaeser/wlmaker/issues/439)).
 
 ## [0.7](https://github.com/phkaeser/wlmaker/releases/tag/v0.7)
 

--- a/src/xwl.c
+++ b/src/xwl.c
@@ -56,7 +56,6 @@
  *   properties for the window types.
  */
 
-
 #include "xwl.h"
 
 #if defined(WLMAKER_HAVE_XWAYLAND)


### PR DESCRIPTION
Fixes #439 