### PR TITLE
keyboard: Permit  config section as fallback, and stop fatally if keyboard or pointer initialization fails.

### DIFF
--- a/doc/ROADMAP.md
+++ b/doc/ROADMAP.md
@@ -67,6 +67,7 @@ See the [Detailed Feature List](FEATURES.md) for details.
 * [done] Bug fixes
   * [done] Fixes lost keyboard layout group when switching to VT and back ([#449](https://github.com/phkaeser/wlmaker/issues/449)).
   * [done] Fixes mouse-click after task-switch going to previous toplevel ([#475](https://github.com/phkaeser/wlmaker/issues/475)).
+  * [done] Fixes crash on distributions without `XkbConfigurationFile` ([495](https://github.com/phkaeser/wlmaker/issues/495)).
 
 ## [0.7.1](https://github.com/phkaeser/wlmaker/releases/tag/v0.7.1)
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -26,7 +26,9 @@ keys:
 ## Keyboard {#config_keyboard}
 
 This dictionary configures the keyboard layout and properties. It must contain
-either `XkbConfigurationFile` or `XkbRMLVO`.
+`XkbConfigurationFile` and/or `XkbRMLVO`. If the `XkbConfigurationFile` setting
+is present, and the keyboard configuration file is found and can be parsed, it
+will take precedence over the `XkbRMLVO` configuration.
 
 * `XkbConfigurationFile`: Path to the sytem's keyboard configuration file. See
   `keyboard(5)` for that file's format.

--- a/etc/Config.plist
+++ b/etc/Config.plist
@@ -4,17 +4,18 @@
 // Base configuration for wlmaker: Keyboard and autostarted applications.
 {
     Keyboard = {
-        // Use system-wide configuration. See keyboard(5).
-        XkbConfigurationFile = "/etc/default/keyboard";
+        // Use system-wide configuration. See keyboard(5). Takes precedence
+        // over `XkbRMLVO`.
+        XkbConfigurationFile = "/etc/default/keyboardFIXME";
 
         // Alternatively: Specify the keyboard properties directly.
-        // XkbRMLVO = {
-        //     Rules = "evdev";
-        //     Model = "pc105";
-        //     Layout = "us";
-        //     Variant = "intl";
-        //     Options = "";
-        // };
+        XkbRMLVO = {
+            Rules = "evdev";
+            Model = "pc105";
+            Layout = "us";
+            Variant = "intl";
+            Options = "";
+        };
 
         Repeat = {
             // Delay before initiating repeats, in milliseconds.

--- a/src/input/keyboard.c
+++ b/src/input/keyboard.c
@@ -240,12 +240,13 @@ bspl_dict_t *_wlmim_keyboard_populate_rules(
                 fname_ptr,
                 _wlmim_keyboard_config_ini_handler,
                 rmlvo)) {
-            bs_log(BS_ERROR, "Failed to parse \"XkbConfigurationFile\" at %s",
-                   fname_ptr);
+            bs_log(BS_WARNING, "Failed to parse \"XkbConfigurationFile\" at "
+                   "%s, falling back to \"XkbRMLVO\" section.", fname_ptr);
             bspl_dict_unref(rmlvo);
-            return NULL;
+            rmlvo = NULL;
         }
-    } else {
+    }
+    if (NULL == rmlvo) {
         rmlvo = bspl_dict_ref(bspl_dict_get_dict(dict_ptr, "XkbRMLVO"));
     }
 

--- a/src/input/manager.c
+++ b/src/input/manager.c
@@ -354,14 +354,18 @@ void _wlmim_handle_new_input_device(
             wlr_keyboard_from_input_device(wlr_input_device_ptr),
             input_manager_ptr->wlr_seat_ptr,
             wlmtk_root_element(input_manager_ptr->root_ptr));
-        if (NULL != handle_ptr) {
-            if (!_wlmim_device_register(
-                    input_manager_ptr,
-                    wlr_input_device_ptr,
-                    handle_ptr)) {
-                bs_log(BS_ERROR, "Failed _wlim_device_register()");
-                wlmim_keyboard_destroy(handle_ptr);
-            }
+        if (NULL == handle_ptr) {
+            // Abort if we cannot create the keyboard for the device.
+            bs_log(BS_FATAL, "Failed wlmim_keyboard_create()");
+            break;
+        }
+
+        if (!_wlmim_device_register(
+                input_manager_ptr,
+                wlr_input_device_ptr,
+                handle_ptr)) {
+            bs_log(BS_FATAL, "Failed _wlim_device_register()");
+            wlmim_keyboard_destroy(handle_ptr);
         }
         break;
 
@@ -375,19 +379,23 @@ void _wlmim_handle_new_input_device(
         handle_ptr = wlmim_pointer_create(
             wlr_input_device_ptr,
             &input_manager_ptr->pointer_options);
-        if (NULL != handle_ptr) {
-            if (!_wlmim_device_register(
-                    input_manager_ptr,
-                    wlr_input_device_ptr,
-                    handle_ptr)) {
-                bs_log(BS_ERROR, "Failed _wlim_device_register()");
-                wlmim_keyboard_destroy(handle_ptr);
-            } else if (wlmim_pointer_enabled(handle_ptr) &&
-                       NULL != input_manager_ptr->cursor_ptr) {
-                wlmim_cursor_attach_input_device(
-                    input_manager_ptr->cursor_ptr,
-                    wlr_input_device_ptr);
-            }
+        if (NULL == handle_ptr) {
+            // Abort if we cannot create the keyboard for the device.
+            bs_log(BS_FATAL, "Failed wlmim_pointer_create()");
+            break;
+        }
+
+        if (!_wlmim_device_register(
+                input_manager_ptr,
+                wlr_input_device_ptr,
+                handle_ptr)) {
+            bs_log(BS_ERROR, "Failed _wlim_device_register()");
+            wlmim_keyboard_destroy(handle_ptr);
+        } else if (wlmim_pointer_enabled(handle_ptr) &&
+                   NULL != input_manager_ptr->cursor_ptr) {
+            wlmim_cursor_attach_input_device(
+                input_manager_ptr->cursor_ptr,
+                wlr_input_device_ptr);
         }
         break;
 


### PR DESCRIPTION
Addresses the need of having a means for configuring the keyboard on OpenSUSE, addressing the immediate issue of #495.